### PR TITLE
Restart ESP on ping failure

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -674,8 +674,11 @@ void loop()
 
         #if PINGER_SUPPORTED == 1
             //frequently check if gateway is reachable
-            if (pinger.Ping(GATEWAY_IP) == false)
-                WiFi.disconnect();
+            if (pinger.Ping(GATEWAY_IP) == false) {
+                digitalWrite(LED_RT, 1);
+                delay(3000);
+                ESP.restart();
+            }
         #endif
 
         RefreshTimer = now;


### PR DESCRIPTION
<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

This PR addresses the WiFi reconnection issue described in #298. If the pinger is unable to ping the gateway, then the ESP is restarted. I'm open to suggestions for a better approach.

# How Has This Been Tested?

I have been running this firmware for more than two months without any issues. On average, the device is restarted twice per day. I suspect this may also be related to the behavior of the access point.

## Inverter type
- [x] Simulated inverter
- [X] SPH-6000 BL-UP

## Stick type
- [ ] Shine X
- [X] Shine S
- [x] Lolin32
- [ ] Nodemcu32
