### PR TITLE
Add /metrics endpoint as Prometheus exporter

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -32,6 +32,7 @@ class Growatt {
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
   void CreateJson(ShineJsonDocument& doc, String MacAddress);
   void CreateUIJson(ShineJsonDocument& doc);
+  void CreateMetrics(StringStream& metrics, String MacAddress);
 
  private:
   eDevice_t _eDevice;
@@ -41,7 +42,10 @@ class Growatt {
 
   eDevice_t _InitModbusCommunication();
   double roundByResolution(const double& value, const float& resolution);
-  void JSONAddReg(sGrowattModbusReg_t* reg, JsonDocument& doc);
+  double getRegValue(sGrowattModbusReg_t* reg);
+  void camelCaseToUnderscore(String input, char* output);
+  void metricsAddValue(String name, double value, StringStream& metrics,
+                       String MacAddress);
   std::tuple<bool, String> handleEcho(const JsonDocument& req,
                                       JsonDocument& res, Growatt& inverter);
   std::tuple<bool, String> handleCommandList(const JsonDocument& req,

--- a/SRC/ShineWiFi-ModBus/GrowattTypes.h
+++ b/SRC/ShineWiFi-ModBus/GrowattTypes.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Arduino.h"
 #include <ArduinoJson.h>
+#include <StreamUtils.h>
 
 #define JSON_DOCUMENT_SIZE 2048
 #define BUFFER_SIZE 256

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -314,6 +314,7 @@ void setup()
 
     httpServer.on("/status", sendJsonSite);
     httpServer.on("/uiStatus", sendUiJsonSite);
+    httpServer.on("/metrics", sendMetrics);
     httpServer.on("/startAp", startConfigAccessPoint);
     #if ENABLE_MODBUS_COMMUNICATION == 1 
     httpServer.on("/postCommunicationModbus", sendPostSite);
@@ -391,6 +392,19 @@ void sendUiJsonSite(void)
     Inverter.CreateUIJson(doc);
 
     sendJson(doc);
+}
+
+void sendMetrics(void)
+{
+    StringStream metrics;
+    Inverter.CreateMetrics(metrics, WiFi.macAddress());
+
+    httpServer.setContentLength(metrics.available());
+    httpServer.send(200, "text/plain", "");
+    WiFiClient client = httpServer.client();
+    WriteBufferingStream bufferedWifiClient{client, BUFFER_SIZE};
+    while (metrics.available())
+        bufferedWifiClient.write(metrics.read());
 }
 
 #if MQTT_SUPPORTED == 1


### PR DESCRIPTION
<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

This pull request adds a new `/metrics` endpoint that exposes the same data available from `/status` using the Prometheus exporter format instead of the JSON format. This feature is useful because it is now possible to scrape the metrics from a Prometheus server. All the metrics start with `growatt_` (i.e. `growatt_pv1_voltage`) and they have a `mac` label set to the MAC address of the device.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [X] Simulated inverter
- [X] Growatt SPH-6000 BL-UP

## Stick type
- [ ] Shine X
- [X] Shine S
- [x] Lolin32
- [ ] Nodemcu32
