### PR TITLE
Fix error in snake_case conversion

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -567,10 +567,11 @@ void Growatt::CreateUIJson(ShineJsonDocument& doc) {
 #endif  // SIMULATE_INVERTER
 }
 
-void Growatt::camelCaseToUnderscore(String input, char* output) {
+void Growatt::camelCaseToSnakeCase(String input, char* output) {
   int outputIndex = 0;
   for (int i = 0; input[i] != '\0'; i++) {
-    if (isUpperCase(input[i]) && isLowerCase(input[i + 1]) && i != 0) {
+    if (i > 0 && i < input.length() - 1 && isUpperCase(input[i]) &&
+        (isLowerCase(input[i - 1]) || isLowerCase(input[i + 1]))) {
       output[outputIndex++] = '_';
     }
     output[outputIndex++] = toLowerCase(input[i]);
@@ -580,11 +581,11 @@ void Growatt::camelCaseToUnderscore(String input, char* output) {
 
 void Growatt::metricsAddValue(String name, double value, StringStream& metrics,
                               String MacAddress) {
-  char nameUnderscore[name.length() + 10];
-  camelCaseToUnderscore(name, nameUnderscore);
+  char nameSnakeCase[name.length() + 10];
+  camelCaseToSnakeCase(name, nameSnakeCase);
 
   metrics.print("growatt_");
-  metrics.print(nameUnderscore);
+  metrics.print(nameSnakeCase);
   metrics.print("{mac=\"");
   metrics.print(MacAddress);
   metrics.printf("\"} %g\n", value);

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -43,7 +43,7 @@ class Growatt {
   eDevice_t _InitModbusCommunication();
   double roundByResolution(const double& value, const float& resolution);
   double getRegValue(sGrowattModbusReg_t* reg);
-  void camelCaseToUnderscore(String input, char* output);
+  void camelCaseToSnakeCase(String input, char* output);
   void metricsAddValue(String name, double value, StringStream& metrics,
                        String MacAddress);
   std::tuple<bool, String> handleEcho(const JsonDocument& req,


### PR DESCRIPTION
# Description

This pull request fixes an error for which the snake case conversion was not correctly handled for the metric `TemperatureInsideIPM`. The incorrect returned value was `growatt_temperature_insideipm`, while the correct value now is `growatt_temperature_inside_ipm`.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [X] Simulated inverter
- [X] Growatt SPH-6000 BL-UP

## Stick type
- [ ] Shine X
- [X] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
