### PR TITLE
Bugfix - Update GrowattSPF.cpp

### DIFF
--- a/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
@@ -82,11 +82,11 @@ void init_growattSPF(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   Protocol.InputRegisters[SPF_AC_INVA] = sGrowattModbusReg_t{
       38, 0, SIZE_32BIT, F("ACInVA"), 0.1, 0.1, VA, true, false};  // #26
   Protocol.InputRegisters[SPF_BATT_PWR] = sGrowattModbusReg_t{
-      77, 0, SIZE_32BIT, F("BattPwr"), 0.1, 0.1, POWER_W, true, false};  // #27
+      77, 0, SIZE_32BIT_S, F("BattPwr"), 0.1, 0.1, POWER_W, true, false};  // #27
 
   Protocol.InputFragmentCount = 2;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 40};
-  Protocol.InputReadFragments[1] = sGrowattReadFragment_t{77, 79};
+  Protocol.InputReadFragments[1] = sGrowattReadFragment_t{77, 80};
 
   Protocol.HoldingRegisterCount = 0;
   Protocol.HoldingFragmentCount = 0;


### PR DESCRIPTION
Battery Power used wrong size. Correct is sigend 32BIT (SIZE_32BIT_S). Updated modbus second fragment size (from 3 to 4 pos).

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Please include a summary of the change and which issue is fixed.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
SPF 6000 ES

## Stick type
Lolin32
