### PR TITLE
Fix some typos (found by `codespell` and `typos`)

### DIFF
--- a/Doc/ShineWiFi-X/ShineWiFi-X.md
+++ b/Doc/ShineWiFi-X/ShineWiFi-X.md
@@ -96,7 +96,7 @@ Initial loading of Firmware to the stick is very easy:
 
 Remove the stick's PCB from the housing.
 Temporarily  connect the header's Pins GPIO0 and GND while powering-on (plugging in) the stick.
-Remember to install the USB-driver for the USB-to-Serial chip if neededby your computer's OS.
+Remember to install the USB driver for the USB-to-Serial chip if needed by your computer's OS.
 Upload of the compiled binary of the firmware. (using arduino-ide, esptool or avrdude, whatever you prefer)
 
 I have used a male dupont-wire pushed in place while plugging into my USB-extension cord.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Implemented Features:
 * Show a simple live graph visualization  (`http://<ip>`) with help from highcharts.com
 * Firmware update via wifiManager
 * It supports basic access to arbitrary modbus data
-* It tries to autodected which stick type to use
+* It tries to autodetect which stick type to use
 * Wifi manager with own access point for initial configuration of Wifi and MQTT server (IP: 192.168.4.1, SSID: GrowattConfig, Pass: growsolar)
 * Currently Growatt v1.20, v1.24 and v3.05 protocols are implemented and can be easily extended/changed to fit anyone's needs
 * TLS support for esp32

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -98,5 +98,5 @@
 
 // Enabling this will make the wifiManager available on the previously configured wifi and ip.
 // This makes it possible to reconnfigure the stick without a direct WIFI connection. This is
-// a security risk as anyone could now remotly update your firmware. 
+// a security risk as anyone could now remotely update your firmware.
 // #define KEEP_AP_CONFIG_CONNECTION 1

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -281,9 +281,9 @@ void setup()
     digitalWrite(LED_BL, 1);
     // Set a timeout so the ESP doesn't hang waiting to be configured, for instance after a power failure
     
-    int connect_timeout_seonds = 15;
+    int connect_timeout_seconds = 15;
     wm.setConfigPortalTimeout(CONFIG_PORTAL_MAX_TIME_SECONDS);
-    wm.setConnectTimeout(connect_timeout_seonds);
+    wm.setConnectTimeout(connect_timeout_seconds);
     // Automatically connect using saved credentials,
     // if connection fails, it starts an access point with the specified name ("GrowattConfig")
     bool res = wm.autoConnect("GrowattConfig", APPassword); // password protected wificonfig ap


### PR DESCRIPTION
# How Has This Been Tested?

- [x] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
