### PR TITLE
fix(mqtt): do not call sendMqttJson if mqtt is disabled

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -654,7 +654,9 @@ void loop()
                     boolean mqttSuccess = false;
 
                     #if MQTT_SUPPORTED == 1
-                    mqttSuccess = sendMqttJson();
+                    if (shineMqtt.mqttEnabled()) {
+                        mqttSuccess = sendMqttJson();
+                    }
                     #endif
                     handleWdtReset(mqttSuccess);
 


### PR DESCRIPTION
# Description

we can disable mqtt be leaving the server address empty. In this case don't waste CPU cycles generating the json and try to connect. We also stop spoiling the log with not connected messages.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
