### PR TITLE
feat(web): ask for confirmation before starting config AP

### DIFF
--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -42,7 +42,7 @@ copies or substantial portions of the Software. -->
   <a href="./status">Json</a> -
   <a href="./uiStatus">UI Json</a> -
   <a href="./debug">Log</a> -
-  <a href="./startAp">Start config access point</a> -
+  <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp">Start config access point</a> -
   <a href="./postCommunicationModbus">RW Modbus</a>
 
 </body>


### PR DESCRIPTION
# Description

if we accidently click on that link we instantly loose connectivity to the esp.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
