### PR TITLE
feat: add option to enable OTA updates

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -20,6 +20,11 @@
 // Setting this define to 0 will disable the MQTT functionality
 #define MQTT_SUPPORTED 1
 
+// Enable OTA update via espota. This is mainly for development purposes and enables updates
+// of the device without physical access. Use at our own risk!
+#define OTA_SUPPORTED 0
+#define OTA_PASSWORD "enter_ota_secret_here"
+
 // Enable direct modbus read/write support via the WebGUI. Enabling this is a potential security issue.
 #define ENABLE_MODBUS_COMMUNICATION 1
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -33,6 +33,10 @@
     #include "ShineMqtt.h"
 #endif
 
+#if OTA_SUPPORTED == 1
+    #include <ArduinoOTA.h>
+#endif
+
 Preferences prefs;
 Growatt Inverter;
 bool StartedConfigAfterBoot = false;
@@ -328,6 +332,11 @@ void setup()
     Inverter.InitProtocol();
     InverterReconnect();
     httpServer.begin();
+
+    #if OTA_SUPPORTED == 1 && defined(OTA_PASSWORD)
+        ArduinoOTA.setPassword(OTA_PASSWORD);
+        ArduinoOTA.begin();
+    #endif
 }
 
 #if MQTT_SUPPORTED == 1
@@ -693,6 +702,11 @@ void loop()
                 delay(3000);
                 ESP.restart();
             }
+        #endif
+
+        #if OTA_SUPPORTED == 1
+            // check for OTA updates
+            ArduinoOTA.handle();
         #endif
 
         RefreshTimer = now;


### PR DESCRIPTION
# Description

This enables OTA updates via espota. Especially during development it is handsome to be able to update the device with first having to switch to AP mode to update the firmware. Especially when the device is connected to a real inverter that is not in the same building.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [x] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [x] Lolin32
- [ ] Nodemcu32
