### PR TITLE
feat(createJson): print a warning if the document overflowed

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -456,6 +456,12 @@ void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress) {
 #endif  // SIMULATE_INVERTER
   doc["Mac"] = MacAddress;
   doc["Cnt"] = _PacketCnt;
+
+  if (doc.overflowed()) {
+    Log.println(
+        F("WARN CreateJson: ShineJsonDocument overflowed! Output will be "
+          "truncated."));
+  }
 }
 
 void Growatt::CreateUIJson(ShineJsonDocument& doc) {
@@ -551,6 +557,12 @@ void Growatt::CreateUIJson(ShineJsonDocument& doc) {
   arr.add("kWh");
   arr.add(false);
 #endif  // SIMULATE_INVERTER
+
+  if (doc.overflowed()) {
+    Log.println(
+        F("WARN CreateUIJson: ShineJsonDocument overflowed! Output will be "
+          "truncated."));
+  }
 }
 
 void Growatt::camelCaseToSnakeCase(String input, char* output) {


### PR DESCRIPTION
# Description

We use a StaticJsonDocument for all our metrics at the moment. If we define too many metrics the json output will be silently trucated. Increasing the StaticJsonDocument size seems to be an issue at least on the 8266 platform. So print at least a warning for now.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
