### PR TITLE
feat: add hostname and static ip settings

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -66,7 +66,7 @@
 // Data of the Wifi access point
 // Default IP 192.168.4.1
 // Hold down the Button for a few seconds to enter Access Point mode
-#define HOSTNAME          "Growatt"
+#define DEFAULT_HOSTNAME  "Growatt"
 #define APPassword        "growsolar"
 
 // Username and password for firmware update

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -589,46 +589,52 @@ void Growatt::camelCaseToSnakeCase(String input, char* output) {
   output[outputIndex] = '\0';
 }
 
-void Growatt::metricsAddValue(String name, double value, StringStream& metrics,
-                              String MacAddress) {
+void Growatt::metricsAddValue(const String& name, double value,
+                              StringStream& metrics, const String& labels) {
   char nameSnakeCase[name.length() + 10];
   camelCaseToSnakeCase(name, nameSnakeCase);
 
   metrics.print("growatt_");
   metrics.print(nameSnakeCase);
-  metrics.print("{mac=\"");
-  metrics.print(MacAddress);
-  metrics.printf("\"} %g\n", value);
+  metrics.print("{");
+  metrics.print(labels);
+  metrics.printf("} %g\n", value);
 }
 
-void Growatt::CreateMetrics(StringStream& metrics, String MacAddress) {
+void Growatt::CreateMetrics(StringStream& metrics, const String& MacAddress,
+                            const String& Hostname) {
+  String labels;
+  if (Hostname == DEFAULT_HOSTNAME) {
+    labels = "mac=\"" + MacAddress + "\"";
+  } else {
+    labels = "mac=\"" + MacAddress + "\",name=\"" + Hostname + "\"";
+  }
 #if SIMULATE_INVERTER != 1
   for (int i = 0; i < _Protocol.InputRegisterCount; i++)
     metricsAddValue(_Protocol.InputRegisters[i].name,
-                    getRegValue(&_Protocol.InputRegisters[i]), metrics,
-                    MacAddress);
+                    getRegValue(&_Protocol.InputRegisters[i]), metrics, labels);
 
   for (int i = 0; i < _Protocol.HoldingRegisterCount; i++)
     metricsAddValue(_Protocol.HoldingRegisters[i].name,
                     getRegValue(&_Protocol.HoldingRegisters[i]), metrics,
-                    MacAddress);
+                    labels);
 
 #else
 #warning simulating the inverter
-  metricsAddValue("Status", 1, metrics, MacAddress);
-  metricsAddValue("DcPower", 230, metrics, MacAddress);
-  metricsAddValue("DcVoltage", 70.5, metrics, MacAddress);
-  metricsAddValue("DcInputCurrent", 8.5, metrics, MacAddress);
-  metricsAddValue("AcFreq", 50.00, metrics, MacAddress);
-  metricsAddValue("AcVoltage", 230.0, metrics, MacAddress);
-  metricsAddValue("AcPower", 0.00, metrics, MacAddress);
-  metricsAddValue("EnergyToday", 0.3, metrics, MacAddress);
-  metricsAddValue("EnergyTotal", 49.1, metrics, MacAddress);
-  metricsAddValue("OperatingTime", 123456, metrics, MacAddress);
-  metricsAddValue("Temperature", 21.12, metrics, MacAddress);
-  metricsAddValue("AccumulatedEnergy", 320, metrics, MacAddress);
+  metricsAddValue("Status", 1, metrics, labels);
+  metricsAddValue("DcPower", 230, metrics, labels);
+  metricsAddValue("DcVoltage", 70.5, metrics, labels);
+  metricsAddValue("DcInputCurrent", 8.5, metrics, labels);
+  metricsAddValue("AcFreq", 50.00, metrics, labels);
+  metricsAddValue("AcVoltage", 230.0, metrics, labels);
+  metricsAddValue("AcPower", 0.00, metrics, labels);
+  metricsAddValue("EnergyToday", 0.3, metrics, labels);
+  metricsAddValue("EnergyTotal", 49.1, metrics, labels);
+  metricsAddValue("OperatingTime", 123456, metrics, labels);
+  metricsAddValue("Temperature", 21.12, metrics, labels);
+  metricsAddValue("AccumulatedEnergy", 320, metrics, labels);
 #endif  // SIMULATE_INVERTER
-  metricsAddValue("Cnt", _PacketCnt, metrics, MacAddress);
+  metricsAddValue("Cnt", _PacketCnt, metrics, labels);
 }
 
 void Growatt::RegisterCommand(const String& command,

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -430,7 +430,11 @@ double Growatt::getRegValue(sGrowattModbusReg_t* reg) {
   return result;
 }
 
-void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress) {
+void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress,
+                         String Hostname) {
+  if (!Hostname.isEmpty()) {
+    doc["Hostname"] = Hostname;
+  }
 #if SIMULATE_INVERTER != 1
   for (int i = 0; i < _Protocol.InputRegisterCount; i++)
     doc[_Protocol.InputRegisters[i].name] =

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -468,12 +468,19 @@ void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress,
   }
 }
 
-void Growatt::CreateUIJson(ShineJsonDocument& doc) {
+void Growatt::CreateUIJson(ShineJsonDocument& doc, String Hostname) {
 #if SIMULATE_INVERTER != 1
   const char* unitStr[] = {"",  "W", "kWh", "V",  "A",
                            "s", "%", "Hz",  "°C", "VA"};
   const char* statusStr[] = {"(Waiting)", "(Normal Operation)", "", "(Error)"};
   const int statusStrLength = sizeof(statusStr) / sizeof(char*);
+
+  if (!Hostname.isEmpty()) {
+    JsonArray arr = doc.createNestedArray("Hostname");
+    arr.add(Hostname);
+    arr.add("");
+    arr.add(false);
+  }
 
   for (int i = 0; i < _Protocol.InputRegisterCount; i++) {
     if (_Protocol.InputRegisters[i].frontend == true ||

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -32,7 +32,8 @@ class Growatt {
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
   void CreateJson(ShineJsonDocument& doc, String MacAddress, String Hostname);
   void CreateUIJson(ShineJsonDocument& doc, String Hostname);
-  void CreateMetrics(StringStream& metrics, String MacAddress);
+  void CreateMetrics(StringStream& metrics, const String& MacAddress,
+                     const String& Hostname);
 
  private:
   eDevice_t _eDevice;
@@ -44,8 +45,8 @@ class Growatt {
   double roundByResolution(const double& value, const float& resolution);
   double getRegValue(sGrowattModbusReg_t* reg);
   void camelCaseToSnakeCase(String input, char* output);
-  void metricsAddValue(String name, double value, StringStream& metrics,
-                       String MacAddress);
+  void metricsAddValue(const String& name, double value, StringStream& metrics,
+                       const String& labels);
   std::tuple<bool, String> handleEcho(const JsonDocument& req,
                                       JsonDocument& res, Growatt& inverter);
   std::tuple<bool, String> handleCommandList(const JsonDocument& req,

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -30,7 +30,7 @@ class Growatt {
   bool ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint32_t* result);
   bool WriteHoldingReg(uint16_t adr, uint16_t value);
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
-  void CreateJson(ShineJsonDocument& doc, String MacAddress);
+  void CreateJson(ShineJsonDocument& doc, String MacAddress, String Hostname);
   void CreateUIJson(ShineJsonDocument& doc);
   void CreateMetrics(StringStream& metrics, String MacAddress);
 

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -31,7 +31,7 @@ class Growatt {
   bool WriteHoldingReg(uint16_t adr, uint16_t value);
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
   void CreateJson(ShineJsonDocument& doc, String MacAddress, String Hostname);
-  void CreateUIJson(ShineJsonDocument& doc);
+  void CreateUIJson(ShineJsonDocument& doc, String Hostname);
   void CreateMetrics(StringStream& metrics, String MacAddress);
 
  private:

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -34,7 +34,7 @@ String ShineMqtt::getId() {
 #elif ESP32
   uint64_t id = ESP.getEfuseMac();
 #endif
-  return HOSTNAME + String(id & 0xffffffff);
+  return DEFAULT_HOSTNAME + String(id & 0xffffffff);
 }
 
 boolean ShineMqtt::mqttEnabled() { return !this->mqttconfig.server.isEmpty(); }

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.h
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.h
@@ -10,11 +10,11 @@
 #include <stdbool.h>
 
 typedef struct {
-  String mqttserver;
-  String mqttport;
-  String mqtttopic;
-  String mqttuser;
-  String mqttpwd;
+  String server;
+  String port;
+  String topic;
+  String user;
+  String pwd;
 } MqttConfig;
 
 class ShineMqtt {

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -68,21 +68,48 @@ uint16_t u16PacketCnt = 0;
     WebServer httpServer(80);
 #endif
 
-
 WiFiManager wm;
-#if MQTT_SUPPORTED == 1
-    WiFiManagerParameter* custom_mqtt_server = NULL;
-    WiFiManagerParameter* custom_mqtt_port = NULL;
-    WiFiManagerParameter* custom_mqtt_topic = NULL;
-    WiFiManagerParameter* custom_mqtt_user = NULL;
-    WiFiManagerParameter* custom_mqtt_pwd = NULL;
 
-    const static char* serverfile = "/mqtts";
-    const static char* portfile = "/mqttp";
-    const static char* topicfile = "/mqttt";
-    const static char* userfile = "/mqttu";
-    const static char* secretfile = "/mqttw";
+struct {
+    WiFiManagerParameter* hostname = NULL;
+    WiFiManagerParameter* static_ip = NULL;
+    WiFiManagerParameter* static_netmask = NULL;
+    WiFiManagerParameter* static_gateway = NULL;
+    WiFiManagerParameter* static_dns = NULL;
+#if MQTT_SUPPORTED == 1
+    WiFiManagerParameter* mqtt_server = NULL;
+    WiFiManagerParameter* mqtt_port = NULL;
+    WiFiManagerParameter* mqtt_topic = NULL;
+    WiFiManagerParameter* mqtt_user = NULL;
+    WiFiManagerParameter* mqtt_pwd = NULL;
 #endif
+} customWMParams;
+
+static const struct {
+    String hostname = "/hostname";
+    String static_ip = "/staticip";
+    String static_netmask = "/staticnetmask";
+    String static_gateway = "/staticgateway";
+    String static_dns = "/staticdns";
+#if MQTT_SUPPORTED == 1
+    String mqtt_server = "/mqtts";
+    String mqtt_port = "/mqttp";
+    String mqtt_topic = "/mqttt";
+    String mqtt_user = "/mqttu";
+    String mqtt_pwd = "/mqttw";
+#endif
+} ConfigFiles;
+
+struct {
+  String hostname;
+  String static_ip;
+  String static_netmask;
+  String static_gateway;
+  String static_dns;
+#if MQTT_SUPPORTED == 1
+  MqttConfig mqtt;
+#endif
+} Config;
 
 #define CONFIG_PORTAL_MAX_TIME_SECONDS 300
 
@@ -135,46 +162,67 @@ void InverterReconnect(void)
         Log.println(F("Error: Unknown Shine Stick"));
 }
 
-#if MQTT_SUPPORTED == 1
-void loadConfig(MqttConfig* config);
-void saveConfig(MqttConfig* config);
+void loadConfig();
+void saveConfig();
 void saveParamCallback();
-void setupMqttWifiManagerMenu(MqttConfig &mqttConfig);
+void setupWifiManagerConfigMenu();
 
-void loadConfig(MqttConfig* config)
+void loadConfig()
 {
-    config->mqttserver = prefs.getString(serverfile, "10.1.2.3");
-    config->mqttport = prefs.getString(portfile, "1883");
-    config->mqtttopic = prefs.getString(topicfile, "energy/solar");
-    config->mqttuser = prefs.getString(userfile, "");
-    config->mqttpwd = prefs.getString(secretfile, "");
+    Config.hostname = prefs.getString(ConfigFiles.hostname.c_str(), HOSTNAME);
+    Config.static_ip = prefs.getString(ConfigFiles.static_ip.c_str(), "");
+    Config.static_netmask = prefs.getString(ConfigFiles.static_netmask.c_str(), "");
+    Config.static_gateway = prefs.getString(ConfigFiles.static_gateway.c_str(), "");
+    Config.static_dns = prefs.getString(ConfigFiles.static_dns.c_str(), "");
+#if MQTT_SUPPORTED == 1
+    Config.mqtt.server = prefs.getString(ConfigFiles.mqtt_server.c_str(), "10.1.2.3");
+    Config.mqtt.port = prefs.getString(ConfigFiles.mqtt_port.c_str(), "1883");
+    Config.mqtt.topic = prefs.getString(ConfigFiles.mqtt_topic.c_str(), "energy/solar");
+    Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user.c_str(), "");
+    Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd.c_str(), "");
+#endif
 }
 
-void saveConfig(MqttConfig* config)
+void saveConfig()
 {
-    prefs.putString(serverfile, config->mqttserver);
-    prefs.putString(portfile, config->mqttport);
-    prefs.putString(topicfile, config->mqtttopic);
-    prefs.putString(userfile, config->mqttuser);
-    prefs.putString(secretfile, config->mqttpwd);
+    prefs.putString(ConfigFiles.hostname.c_str(), Config.hostname);
+    prefs.putString(ConfigFiles.static_ip.c_str(), Config.static_ip);
+    prefs.putString(ConfigFiles.static_netmask.c_str(), Config.static_netmask);
+    prefs.putString(ConfigFiles.static_gateway.c_str(), Config.static_gateway);
+    prefs.putString(ConfigFiles.static_dns.c_str(), Config.static_dns);
+#if MQTT_SUPPORTED == 1
+    prefs.putString(ConfigFiles.mqtt_server.c_str(), Config.mqtt.server);
+    prefs.putString(ConfigFiles.mqtt_port.c_str(), Config.mqtt.port);
+    prefs.putString(ConfigFiles.mqtt_topic.c_str(), Config.mqtt.topic);
+    prefs.putString(ConfigFiles.mqtt_user.c_str(), Config.mqtt.user);
+    prefs.putString(ConfigFiles.mqtt_pwd.c_str(), Config.mqtt.pwd);
+#endif
 }
 
 void saveParamCallback()
 {
     Log.println(F("[CALLBACK] saveParamCallback fired"));
-    MqttConfig config;
 
-    config.mqttserver = custom_mqtt_server->getValue();
-    config.mqttport = custom_mqtt_port->getValue();
-    config.mqtttopic = custom_mqtt_topic->getValue();
-    config.mqttuser = custom_mqtt_user->getValue();
-    config.mqttpwd = custom_mqtt_pwd->getValue();
+    Config.hostname = customWMParams.hostname->getValue();
+    if (Config.hostname.isEmpty()) {
+        Config.hostname = HOSTNAME;
+    }
+    Config.static_ip = customWMParams.static_ip->getValue();
+    Config.static_netmask = customWMParams.static_netmask->getValue();
+    Config.static_gateway = customWMParams.static_gateway->getValue();
+    Config.static_dns = customWMParams.static_dns->getValue();
+#if MQTT_SUPPORTED == 1
+    Config.mqtt.server = customWMParams.mqtt_server->getValue();
+    Config.mqtt.port = customWMParams.mqtt_port->getValue();
+    Config.mqtt.topic = customWMParams.mqtt_topic->getValue();
+    Config.mqtt.user = customWMParams.mqtt_user->getValue();
+    Config.mqtt.pwd = customWMParams.mqtt_pwd->getValue();
+#endif
 
-    saveConfig(&config);
+    saveConfig();
 
     Serial.println(F("[CALLBACK] saveParamCallback complete"));
 }
-#endif
 
 #ifdef ENABLE_TELNET_DEBUG
 #include <TelnetSerialStream.h>
@@ -208,12 +256,13 @@ void setupGPIO()
     pinMode(LED_BL, OUTPUT);    
 }
 
-
 void setupWifiHost()
 {
-    WiFi.hostname(HOSTNAME);
+    WiFi.hostname(Config.hostname);
     WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
-    MDNS.begin(HOSTNAME);
+    MDNS.begin(Config.hostname);
+    Log.print(F("setupWifiHost: hostname "));
+    Log.println(Config.hostname);
 }
 
 void startWdt() 
@@ -259,9 +308,7 @@ void setup()
         drd = new DoubleResetDetector(DRD_TIMEOUT, DRD_ADDRESS);
     #endif
 
-    #if MQTT_SUPPORTED == 1
-        prefs.begin("ShineWifi");
-    #endif
+    prefs.begin("ShineWifi");
 
     #if ENABLE_DOUBLE_RESET == 1
         if (drd->detectDoubleReset()) {
@@ -270,17 +317,13 @@ void setup()
         }
     #endif
 
+    loadConfig();
     setupWifiHost();
 
     Log.begin();
     startWdt();
 
-    #if MQTT_SUPPORTED == 1
-        MqttConfig mqttConfig;
-        setupMqttWifiManagerMenu(mqttConfig);
-    #else
-        setupMenu(false);    
-    #endif
+    setupWifiManagerConfigMenu();
 
     digitalWrite(LED_BL, 1);
     // Set a timeout so the ESP doesn't hang waiting to be configured, for instance after a power failure
@@ -288,6 +331,28 @@ void setup()
     int connect_timeout_seconds = 15;
     wm.setConfigPortalTimeout(CONFIG_PORTAL_MAX_TIME_SECONDS);
     wm.setConnectTimeout(connect_timeout_seconds);
+
+    // Set static ip
+    if (!Config.static_ip.isEmpty() && !Config.static_netmask.isEmpty()) {
+        IPAddress ip, netmask, gateway, dns;
+        ip.fromString(Config.static_ip);
+        netmask.fromString(Config.static_netmask);
+        gateway.fromString(Config.static_gateway);
+        dns.fromString(Config.static_dns);
+        Log.print(F("static ip: "));
+        Log.println(Config.static_ip);
+        Log.print(F("static netmask: "));
+        Log.println(Config.static_netmask);
+        Log.print(F("static gateway: "));
+        Log.println(Config.static_gateway);
+        Log.print(F("static dns: "));
+        Log.println(Config.static_dns);
+        if (!Config.static_dns.isEmpty()) {
+            wm.setSTAStaticIPConfig(ip, gateway, netmask, dns);
+        } else {
+            wm.setSTAStaticIPConfig(ip, gateway, netmask);
+        }
+    }
     // Automatically connect using saved credentials,
     // if connection fails, it starts an access point with the specified name ("GrowattConfig")
     bool res = wm.autoConnect("GrowattConfig", APPassword); // password protected wificonfig ap
@@ -313,7 +378,7 @@ void setup()
         #ifdef MQTTS_ENABLED
             espClient.setCACert(MQTTS_BROKER_CA_CERT);
         #endif
-        shineMqtt.mqttSetup(mqttConfig);
+        shineMqtt.mqttSetup(Config.mqtt);
     #endif
 
     httpServer.on("/status", sendJsonSite);
@@ -340,26 +405,39 @@ void setup()
     #endif
 }
 
+
+void setupWifiManagerConfigMenu() {
+    customWMParams.hostname = new WiFiManagerParameter("hostname", "hostname (no spaces or special chars)", Config.hostname.c_str(), 30);
+    customWMParams.static_ip = new WiFiManagerParameter("staticip", "ip", Config.static_ip.c_str(), 15);
+    customWMParams.static_netmask = new WiFiManagerParameter("staticnetmask", "netmask", Config.static_netmask.c_str(), 15);
+    customWMParams.static_gateway = new WiFiManagerParameter("staticgateway", "gateway", Config.static_gateway.c_str(), 15);
+    customWMParams.static_dns = new WiFiManagerParameter("staticdns", "dns", Config.static_dns.c_str(), 15);
 #if MQTT_SUPPORTED == 1
-void setupMqttWifiManagerMenu(MqttConfig &mqttConfig) {
-    loadConfig(&mqttConfig);
+    customWMParams.mqtt_server = new WiFiManagerParameter("mqttserver", "server", Config.mqtt.server.c_str(), 40);
+    customWMParams.mqtt_port = new WiFiManagerParameter("mqttport", "port", Config.mqtt.port.c_str(), 6);
+    customWMParams.mqtt_topic = new WiFiManagerParameter("mqtttopic", "topic", Config.mqtt.topic.c_str(), 64);
+    customWMParams.mqtt_user = new WiFiManagerParameter("mqttusername", "username", Config.mqtt.user.c_str(), 40);
+    customWMParams.mqtt_pwd = new WiFiManagerParameter("mqttpassword", "password", Config.mqtt.pwd.c_str(), 64);
+#endif
+    wm.addParameter(customWMParams.hostname);
+#if MQTT_SUPPORTED == 1
+    wm.addParameter(new WiFiManagerParameter("<p><b>MQTT Settings</b> (leave server blank to disable)</p>"));
+    wm.addParameter(customWMParams.mqtt_server);
+    wm.addParameter(customWMParams.mqtt_port);
+    wm.addParameter(customWMParams.mqtt_topic);
+    wm.addParameter(customWMParams.mqtt_user);
+    wm.addParameter(customWMParams.mqtt_pwd);
+#endif
+    wm.addParameter(new WiFiManagerParameter("<p><b>Static IP</b> (leave blank for DHCP)</p>"));
+    wm.addParameter(customWMParams.static_ip);
+    wm.addParameter(customWMParams.static_netmask);
+    wm.addParameter(customWMParams.static_gateway);
+    wm.addParameter(customWMParams.static_dns);
 
-    custom_mqtt_server = new WiFiManagerParameter("server", "mqtt server", mqttConfig.mqttserver.c_str(), 40);
-    custom_mqtt_port = new WiFiManagerParameter("port", "mqtt port", mqttConfig.mqttport.c_str(), 6);
-    custom_mqtt_topic = new WiFiManagerParameter("topic", "mqtt topic", mqttConfig.mqtttopic.c_str(), 64);
-    custom_mqtt_user = new WiFiManagerParameter("username", "mqtt username", mqttConfig.mqttuser.c_str(), 40);
-    custom_mqtt_pwd = new WiFiManagerParameter("password", "mqtt password", mqttConfig.mqttpwd.c_str(), 64);
-
-    wm.addParameter(custom_mqtt_server);
-    wm.addParameter(custom_mqtt_port);
-    wm.addParameter(custom_mqtt_topic);
-    wm.addParameter(custom_mqtt_user);
-    wm.addParameter(custom_mqtt_pwd);
     wm.setSaveParamsCallback(saveParamCallback);
 
     setupMenu(true);
 }
-#endif
 
 /**
  * @brief create custom wifimanager menu entries

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -469,7 +469,7 @@ void sendJson(ShineJsonDocument&  doc)
 void sendJsonSite(void)
 {
     StaticJsonDocument<JSON_DOCUMENT_SIZE> doc;
-    Inverter.CreateJson(doc, WiFi.macAddress());
+    Inverter.CreateJson(doc, WiFi.macAddress(), Config.hostname);
 
     sendJson(doc);
 }
@@ -503,7 +503,7 @@ boolean sendMqttJson(void)
 {
     StaticJsonDocument<JSON_DOCUMENT_SIZE> doc;
 
-    Inverter.CreateJson(doc, WiFi.macAddress());
+    Inverter.CreateJson(doc, WiFi.macAddress(), "");
     return shineMqtt.mqttPublish(doc);
 }
 #endif

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -136,7 +136,7 @@ void WiFi_Reconnect()
         Log.print(F("local IP:"));
         Log.println(WiFi.localIP());
         Log.print(F("Hostname: "));
-        Log.println(HOSTNAME);
+        Log.println(DEFAULT_HOSTNAME);
 
         Log.println(F("WiFi reconnected"));
 
@@ -169,7 +169,7 @@ void setupWifiManagerConfigMenu();
 
 void loadConfig()
 {
-    Config.hostname = prefs.getString(ConfigFiles.hostname, HOSTNAME);
+    Config.hostname = prefs.getString(ConfigFiles.hostname, DEFAULT_HOSTNAME);
     Config.static_ip = prefs.getString(ConfigFiles.static_ip, "");
     Config.static_netmask = prefs.getString(ConfigFiles.static_netmask, "");
     Config.static_gateway = prefs.getString(ConfigFiles.static_gateway, "");
@@ -205,7 +205,7 @@ void saveParamCallback()
 
     Config.hostname = customWMParams.hostname->getValue();
     if (Config.hostname.isEmpty()) {
-        Config.hostname = HOSTNAME;
+        Config.hostname = DEFAULT_HOSTNAME;
     }
     Config.static_ip = customWMParams.static_ip->getValue();
     Config.static_netmask = customWMParams.static_netmask->getValue();

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -477,7 +477,7 @@ void sendJsonSite(void)
 void sendUiJsonSite(void)
 {
     StaticJsonDocument<JSON_DOCUMENT_SIZE> doc;
-    Inverter.CreateUIJson(doc);
+    Inverter.CreateUIJson(doc, Config.hostname);
 
     sendJson(doc);
 }

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -86,17 +86,17 @@ struct {
 } customWMParams;
 
 static const struct {
-    String hostname = "/hostname";
-    String static_ip = "/staticip";
-    String static_netmask = "/staticnetmask";
-    String static_gateway = "/staticgateway";
-    String static_dns = "/staticdns";
+    const char* hostname = "/hostname";
+    const char* static_ip = "/staticip";
+    const char* static_netmask = "/staticnetmask";
+    const char* static_gateway = "/staticgateway";
+    const char* static_dns = "/staticdns";
 #if MQTT_SUPPORTED == 1
-    String mqtt_server = "/mqtts";
-    String mqtt_port = "/mqttp";
-    String mqtt_topic = "/mqttt";
-    String mqtt_user = "/mqttu";
-    String mqtt_pwd = "/mqttw";
+    const char* mqtt_server = "/mqtts";
+    const char* mqtt_port = "/mqttp";
+    const char* mqtt_topic = "/mqttt";
+    const char* mqtt_user = "/mqttu";
+    const char* mqtt_pwd = "/mqttw";
 #endif
 } ConfigFiles;
 
@@ -169,33 +169,33 @@ void setupWifiManagerConfigMenu();
 
 void loadConfig()
 {
-    Config.hostname = prefs.getString(ConfigFiles.hostname.c_str(), HOSTNAME);
-    Config.static_ip = prefs.getString(ConfigFiles.static_ip.c_str(), "");
-    Config.static_netmask = prefs.getString(ConfigFiles.static_netmask.c_str(), "");
-    Config.static_gateway = prefs.getString(ConfigFiles.static_gateway.c_str(), "");
-    Config.static_dns = prefs.getString(ConfigFiles.static_dns.c_str(), "");
+    Config.hostname = prefs.getString(ConfigFiles.hostname, HOSTNAME);
+    Config.static_ip = prefs.getString(ConfigFiles.static_ip, "");
+    Config.static_netmask = prefs.getString(ConfigFiles.static_netmask, "");
+    Config.static_gateway = prefs.getString(ConfigFiles.static_gateway, "");
+    Config.static_dns = prefs.getString(ConfigFiles.static_dns, "");
 #if MQTT_SUPPORTED == 1
-    Config.mqtt.server = prefs.getString(ConfigFiles.mqtt_server.c_str(), "10.1.2.3");
-    Config.mqtt.port = prefs.getString(ConfigFiles.mqtt_port.c_str(), "1883");
-    Config.mqtt.topic = prefs.getString(ConfigFiles.mqtt_topic.c_str(), "energy/solar");
-    Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user.c_str(), "");
-    Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd.c_str(), "");
+    Config.mqtt.server = prefs.getString(ConfigFiles.mqtt_server, "10.1.2.3");
+    Config.mqtt.port = prefs.getString(ConfigFiles.mqtt_port, "1883");
+    Config.mqtt.topic = prefs.getString(ConfigFiles.mqtt_topic, "energy/solar");
+    Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user, "");
+    Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd, "");
 #endif
 }
 
 void saveConfig()
 {
-    prefs.putString(ConfigFiles.hostname.c_str(), Config.hostname);
-    prefs.putString(ConfigFiles.static_ip.c_str(), Config.static_ip);
-    prefs.putString(ConfigFiles.static_netmask.c_str(), Config.static_netmask);
-    prefs.putString(ConfigFiles.static_gateway.c_str(), Config.static_gateway);
-    prefs.putString(ConfigFiles.static_dns.c_str(), Config.static_dns);
+    prefs.putString(ConfigFiles.hostname, Config.hostname);
+    prefs.putString(ConfigFiles.static_ip, Config.static_ip);
+    prefs.putString(ConfigFiles.static_netmask, Config.static_netmask);
+    prefs.putString(ConfigFiles.static_gateway, Config.static_gateway);
+    prefs.putString(ConfigFiles.static_dns, Config.static_dns);
 #if MQTT_SUPPORTED == 1
-    prefs.putString(ConfigFiles.mqtt_server.c_str(), Config.mqtt.server);
-    prefs.putString(ConfigFiles.mqtt_port.c_str(), Config.mqtt.port);
-    prefs.putString(ConfigFiles.mqtt_topic.c_str(), Config.mqtt.topic);
-    prefs.putString(ConfigFiles.mqtt_user.c_str(), Config.mqtt.user);
-    prefs.putString(ConfigFiles.mqtt_pwd.c_str(), Config.mqtt.pwd);
+    prefs.putString(ConfigFiles.mqtt_server, Config.mqtt.server);
+    prefs.putString(ConfigFiles.mqtt_port, Config.mqtt.port);
+    prefs.putString(ConfigFiles.mqtt_topic, Config.mqtt.topic);
+    prefs.putString(ConfigFiles.mqtt_user, Config.mqtt.user);
+    prefs.putString(ConfigFiles.mqtt_pwd, Config.mqtt.pwd);
 #endif
 }
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -136,7 +136,7 @@ void WiFi_Reconnect()
         Log.print(F("local IP:"));
         Log.println(WiFi.localIP());
         Log.print(F("Hostname: "));
-        Log.println(DEFAULT_HOSTNAME);
+        Log.println(Config.hostname);
 
         Log.println(F("WiFi reconnected"));
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -487,7 +487,7 @@ void sendMetrics(void)
     StringStream metrics;
     char writeBuffer[BUFFER_SIZE];
 
-    Inverter.CreateMetrics(metrics, WiFi.macAddress());
+    Inverter.CreateMetrics(metrics, WiFi.macAddress(), Config.hostname);
 
     httpServer.setContentLength(metrics.available());
     httpServer.send(200, "text/plain", "");


### PR DESCRIPTION
# Description

This adds support for setting a custom hostname and static ip settings.
If more than one inverter is in the installation it is good to be able
to distinguish the different inverters by name.
For sensors it is a good practice to give static ip addresses to them
especially if they are polled.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
