### PR TITLE
feat(webUI): add option to reboot the esp

### DIFF
--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -43,6 +43,7 @@ copies or substantial portions of the Software. -->
   <a href="./uiStatus">UI Json</a> -
   <a href="./debug">Log</a> -
   <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp">Start config access point</a> -
+  <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot">Reboot</a> -
   <a href="./postCommunicationModbus">RW Modbus</a>
 
 </body>

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -316,7 +316,8 @@ void setup()
     httpServer.on("/uiStatus", sendUiJsonSite);
     httpServer.on("/metrics", sendMetrics);
     httpServer.on("/startAp", startConfigAccessPoint);
-    #if ENABLE_MODBUS_COMMUNICATION == 1 
+    httpServer.on("/reboot", rebootESP);
+    #if ENABLE_MODBUS_COMMUNICATION == 1
     httpServer.on("/postCommunicationModbus", sendPostSite);
     httpServer.on("/postCommunicationModbus_p", HTTP_POST, handlePostData);
     #endif 
@@ -425,6 +426,12 @@ void startConfigAccessPoint(void)
     httpServer.send(200, "text/html", msg);
     delay(2000);
     StartedConfigAfterBoot = true;
+}
+
+void rebootESP(void) {
+    httpServer.send(200, F("text/html"), F("<html><body>Rebooting...</body></html>"));
+    delay(2000);
+    ESP.restart();
 }
 
 #ifdef ENABLE_WEB_DEBUG


### PR DESCRIPTION
# Description

This adds support to reboot the ESP to bring it back to a clean state if something is not working properly.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
