### PR TITLE
fix(GrowattTypes): possible oob access in unitStr

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -466,7 +466,8 @@ void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress) {
 
 void Growatt::CreateUIJson(ShineJsonDocument& doc) {
 #if SIMULATE_INVERTER != 1
-  const char* unitStr[] = {"", "W", "kWh", "V", "A", "s", "%", "Hz", "°C"};
+  const char* unitStr[] = {"",  "W", "kWh", "V",  "A",
+                           "s", "%", "Hz",  "°C", "VA"};
   const char* statusStr[] = {"(Waiting)", "(Normal Operation)", "", "(Error)"};
   const int statusStrLength = sizeof(statusStr) / sizeof(char*);
 


### PR DESCRIPTION
# Description

RegisterUnit_t defines one more item than unitStr.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
