### PR TITLE
fix(mainloop): millis() returns unsigned long

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineMqtt.h
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.h
@@ -31,7 +31,7 @@ class ShineMqtt {
 
  private:
   WiFiClient& wifiClient;
-  long previousConnectTryMillis = 0;
+  unsigned long previousConnectTryMillis = 0;
   MqttConfig mqttconfig;
   PubSubClient mqttclient;
   Growatt& inverter;

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -544,10 +544,10 @@ void handlePostData()
 // -------------------------------------------------------
 // Main loop
 // -------------------------------------------------------
-long ButtonTimer = 0;
-long LEDTimer = 0;
-long RefreshTimer = 0;
-long WifiRetryTimer = 0;
+unsigned long ButtonTimer = 0;
+unsigned long LEDTimer = 0;
+unsigned long RefreshTimer = 0;
+unsigned long WifiRetryTimer = 0;
 
 void loop()
 {
@@ -556,7 +556,7 @@ void loop()
     #endif
 
     Log.loop();
-    long now = millis();
+    unsigned long now = millis();
     char readoutSucceeded;
 
 #ifdef AP_BUTTON_PRESSED


### PR DESCRIPTION
# Description

currently the return value of millis() is stored in signed long variables. This will cause a stop of any timers after approx. 25 days when the output of millis() will become negative.
With unsigned long the time difference calcualtion for the timers will also work correctly when the millis() return value spills over after approx. 49 days.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
