### PR TITLE
fix(sendMetrics): avoid copying from buffer to buffer

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -397,14 +397,17 @@ void sendUiJsonSite(void)
 void sendMetrics(void)
 {
     StringStream metrics;
+    char writeBuffer[BUFFER_SIZE];
+
     Inverter.CreateMetrics(metrics, WiFi.macAddress());
 
     httpServer.setContentLength(metrics.available());
     httpServer.send(200, "text/plain", "");
     WiFiClient client = httpServer.client();
-    WriteBufferingStream bufferedWifiClient{client, BUFFER_SIZE};
-    while (metrics.available())
-        bufferedWifiClient.write(metrics.read());
+    while (metrics.available()) {
+        int len = metrics.readBytes(writeBuffer, BUFFER_SIZE);
+        client.write(writeBuffer, len);
+    }
 }
 
 #if MQTT_SUPPORTED == 1


### PR DESCRIPTION
# Description

It turns out the the current sendMetrics implementation is terribly slow. This is most likely because StringStream.read() will return only one character. As StringStream is already able to copy data to WifiClient in chunks avoid the WriteBufferingClient and send the data directly from StringStream to WifiClient.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [x] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [x] Lolin32
- [ ] Nodemcu32
