### PR TITLE
Support overriding PlatformIO config using platformio-local.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ SRC/ShineWiFi-ModBus/Config.h
 
 # PlatformIO
 .pio
+platformio-local.ini
 
 # VisualStudioCode
 .vscode/*

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,8 @@
 [platformio]
 default_envs = ShineWifiX, ShineWifiS, nodemcu-32s, lolin32, d1
 src_dir = SRC/ShineWiFi-ModBus
+extra_configs =
+    platformio-local.ini
 
 [env]
 monitor_speed = 115200


### PR DESCRIPTION
<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Allow extending the PlatformIO configuration locally with a gitignored `platformio-local.ini`. Useful for OTA uploads for example.

```ini
[env]
upload_protocol = espota
upload_port = 1.2.3.4
upload_flags =
    --auth=upload-password-set-in-OTA_PASSWORD
```

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [x] Inverter type e.g. Growatt MOD 7000 TL3-X

## Stick type
- [x] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
