### PR TITLE
refactor(Growatt): don't iterate over registers of already processed …

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -118,6 +118,7 @@ bool Growatt::ReadInputRegisters() {
    */
   uint16_t registerAddress;
   uint8_t res;
+  int j = 0;
 
   // read each fragment separately
   for (int i = 0; i < _Protocol.InputFragmentCount; i++) {
@@ -133,7 +134,7 @@ bool Growatt::ReadInputRegisters() {
 #ifdef DEBUG_MODBUS_OUTPUT
       Log.println(F("ok"));
 #endif
-      for (int j = 0; j < _Protocol.InputRegisterCount; j++) {
+      for (; j < _Protocol.InputRegisterCount; j++) {
         // make sure the register we try to read is in the fragment
         if (_Protocol.InputRegisters[j].address >=
             _Protocol.InputReadFragments[i].StartAddress) {


### PR DESCRIPTION
…fragments in ReadInputRegisters

# Description

we skip to the next fragment if we reach an input register which is not in the address room of the current fragment. So we don't have to interate again over those registers that have already been processed.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt MID 15 TKL3-XH

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
