### PR TITLE
Disable modbus in the default firmware due to security issues

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -26,7 +26,7 @@
 #define OTA_PASSWORD "enter_ota_secret_here"
 
 // Enable direct modbus read/write support via the WebGUI. Enabling this is a potential security issue.
-#define ENABLE_MODBUS_COMMUNICATION 1
+#define ENABLE_MODBUS_COMMUNICATION 0
 
 // Setting this define to 1 will ping the default gateway periodically
 // if the ping is not successful, the wifi connection will be reestablished


### PR DESCRIPTION
# Description

The modbus page gives everyone with access to the web interface full access to the inverter. This pr disables the modbus page by default. You should either use the modbus interface via tls or compile your own firmware if you know what you are doing and want to take the risk.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [x] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [x] Lolin32
- [ ] Nodemcu32
