### PR TITLE
feat: add http command endpoint

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -503,6 +503,7 @@ void handleInverterCommand()
 
 void handleNotFound() {
     if (httpServer.uri().startsWith(F("/command/")) &&
+        // Combined with requiring Content-Type application/json this avoids CORS attacks
         httpServer.method() == HTTP_POST &&
         httpServer.uri().length() > 9) {
         handleInverterCommand();

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -469,8 +469,8 @@ void sendPostSite(void)
 #if ENABLE_HTTP_COMMAND_ENDPOINT == 1
 void handleInverterCommand()
 {
-    StaticJsonDocument<1024> req;
-    StaticJsonDocument<1024> res;
+    StaticJsonDocument<512> req;
+    StaticJsonDocument<512> res;
     const String& cmd = httpServer.uri().substring(9);
     const String& postData = httpServer.arg(F("plain")).length() > 0 ? httpServer.arg(F("plain")) : F("{}");
     Log.print(F("handleInverterCommand: cmd "));


### PR DESCRIPTION
This is an updated version of the http command endpoint patch. This time with forced HTTP method POST and Content-Type application/json as suggested by @slovdahl.
This feature is still disabled by default as it imposes a potential security risk if the ESP is reachable from outside.
As the feature exposes no additional risk compared to the modbus http interface I would ask to reconsider merging this.
If additional security is required (auth-token, authentication, restriction to authorized ips) I am willing to implement this as well.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
