### PR TITLE
fix(Growatt::camelCaseToSnakeCase): single uppercase at the of String

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -569,8 +569,9 @@ void Growatt::CreateUIJson(ShineJsonDocument& doc) {
 void Growatt::camelCaseToSnakeCase(String input, char* output) {
   int outputIndex = 0;
   for (uint i = 0; input[i] != '\0'; i++) {
-    if (i > 0 && i < input.length() - 1 && isUpperCase(input[i]) &&
-        (isLowerCase(input[i - 1]) || isLowerCase(input[i + 1]))) {
+    if (i > 0 && isUpperCase(input[i]) &&
+        (isLowerCase(input[i - 1]) ||
+         (i < input.length() - 1 && isLowerCase(input[i + 1])))) {
       output[outputIndex++] = '_';
     }
     output[outputIndex++] = toLowerCase(input[i]);


### PR DESCRIPTION

# Description
This fixes the missing insertion of an underscore if the last character of the String is uppercase and the second last is lowercase.

E.g. TemperatureA was not correctly converted to temperature_a before.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
