### PR TITLE
feat: add support to set inverter datetime via NTP

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -28,6 +28,11 @@
 // Enable direct modbus read/write support via the WebGUI. Enabling this is a potential security issue.
 #define ENABLE_MODBUS_COMMUNICATION 0
 
+// Define a NTP Server and TZ Info to automatically adjust the inverter date/time.
+// TZ Info can be found at: https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
+#define DEFAULT_NTP_SERVER "europe.pool.ntp.org"
+#define DEFAULT_TZ_INFO "CET-1CEST,M3.5.0,M10.5.0/3"
+
 // Setting this define to 1 will ping the default gateway periodically
 // if the ping is not successful, the wifi connection will be reestablished
 #define PINGER_SUPPORTED 0

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -660,7 +660,7 @@ unsigned long LEDTimer = 0;
 unsigned long RefreshTimer = 0;
 unsigned long WifiRetryTimer = 0;
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
-unsigned long nextNTPSync = 60000; // allow for Wifi to connect and first SNTP sync to happen
+unsigned long lastNTPSync = 0;
 #endif
 
 void loop()
@@ -817,7 +817,9 @@ void loop()
         #endif
 
         #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
-        if (now > nextNTPSync) {
+        // wait 1h between inverter time syncs and wait 60s after
+        // ESP startup for Wifi to connect and first NTP sync to happen.
+        if (now - lastNTPSync > 3600000 && now > 60000) {
             int reachable = sntp_getreachability(0);
             Log.print(F("NTP server: "));
             Log.print(DEFAULT_NTP_SERVER);
@@ -835,7 +837,7 @@ void loop()
                 Inverter.HandleCommand("datetime/set", (byte*) &buff, strlen(buff), req, res);
                 Log.println(res["message"].as<String>());
             }
-            nextNTPSync = now + 3600000;
+            lastNTPSync = now;
         }
         #endif
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -410,7 +410,12 @@ void setup()
     #endif
 
     #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
-        configTime(DEFAULT_TZ_INFO, DEFAULT_NTP_SERVER);
+        #ifdef ESP32
+            configTime(0, 0, DEFAULT_NTP_SERVER);
+            setenv("TZ", DEFAULT_TZ_INFO, 1);
+        #else
+            configTime(DEFAULT_TZ_INFO, DEFAULT_NTP_SERVER);
+        #endif
     #endif
 }
 
@@ -828,7 +833,7 @@ void loop()
                 Log.print(F("Trying to set inverter datetime: "));
                 Log.println(buff);
                 Inverter.HandleCommand("datetime/set", (byte*) &buff, strlen(buff), req, res);
-                Log.println(String(res["message"]));
+                Log.println(res["message"].as<String>());
             }
             nextNTPSync = now + 3600000;
         }

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -652,6 +652,35 @@ void handlePostData()
     }
 }
 
+#if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
+void handleNTPSync() {
+    static unsigned long lastNTPSync = 0;
+    unsigned long now = millis();
+    // wait 1h between inverter time syncs and wait 60s after
+    // ESP startup for Wifi to connect and first NTP sync to happen.
+    if (now - lastNTPSync > 3600000 && now > 60000) {
+        int reachable = sntp_getreachability(0);
+        Log.print(F("NTP server: "));
+        Log.print(DEFAULT_NTP_SERVER);
+        Log.print(F(" reachable "));
+        Log.println(reachable & 1);
+        if (reachable & 1) { // last SNTP request was successful
+            StaticJsonDocument<128> req, res;
+            char buff[32];
+            struct tm tm;
+            time_t t = time(NULL);
+            localtime_r(&t, &tm);
+            strftime(buff, sizeof(buff), "{\"value\":\"%Y-%m-%d %T\"}", &tm);
+            Log.print(F("Trying to set inverter datetime: "));
+            Log.println(buff);
+            Inverter.HandleCommand("datetime/set", (byte*) &buff, strlen(buff), req, res);
+            Log.println(res["message"].as<String>());
+        }
+        lastNTPSync = now;
+    }
+}
+#endif
+
 // -------------------------------------------------------
 // Main loop
 // -------------------------------------------------------
@@ -659,9 +688,6 @@ unsigned long ButtonTimer = 0;
 unsigned long LEDTimer = 0;
 unsigned long RefreshTimer = 0;
 unsigned long WifiRetryTimer = 0;
-#if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
-unsigned long lastNTPSync = 0;
-#endif
 
 void loop()
 {
@@ -817,28 +843,8 @@ void loop()
         #endif
 
         #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
-        // wait 1h between inverter time syncs and wait 60s after
-        // ESP startup for Wifi to connect and first NTP sync to happen.
-        if (now - lastNTPSync > 3600000 && now > 60000) {
-            int reachable = sntp_getreachability(0);
-            Log.print(F("NTP server: "));
-            Log.print(DEFAULT_NTP_SERVER);
-            Log.print(F(" reachable "));
-            Log.println(reachable & 1);
-            if (reachable & 1) { // last SNTP request was successful
-                StaticJsonDocument<128> req, res;
-                char buff[32];
-                struct tm tm;
-                time_t t = time(NULL);
-                localtime_r(&t, &tm);
-                strftime(buff, sizeof(buff), "{\"value\":\"%Y-%m-%d %T\"}", &tm);
-                Log.print(F("Trying to set inverter datetime: "));
-                Log.println(buff);
-                Inverter.HandleCommand("datetime/set", (byte*) &buff, strlen(buff), req, res);
-                Log.println(res["message"].as<String>());
-            }
-            lastNTPSync = now;
-        }
+            // set inverter datetime
+            handleNTPSync();
         #endif
 
         RefreshTimer = now;


### PR DESCRIPTION


# Description

This enables the integrated SNTP timesync mechanism of the ESP and uses this to keep the inverter datetime in sync.

Please refer to Config.h.example on how to set NTP server and timezone.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt MID 15 TKL3-XH

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
