### PR TITLE
fix(shineMqtt): only update LED if mqtt is enabled

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -154,10 +154,11 @@ void ShineMqtt::onMqttMessage(char* topic, byte* payload, unsigned int length) {
 }
 
 void ShineMqtt::updateMqttLed() {
-  if (!this->mqttclient.connected())
+  if (mqttEnabled() && !this->mqttclient.connected()) {
     digitalWrite(LED_RT, 1);
-  else
+  } else {
     digitalWrite(LED_RT, 0);
+  }
 }
 
 void ShineMqtt::loop() { this->mqttclient.loop(); }


### PR DESCRIPTION

# Description

If mqtt is disabled by leaving the server ip empty the red led will always stay on. This fixes this by only calling the updateMqttLed function if mqtt is enabled.

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
