### PR TITLE
fix(WiFi_Reconnect): do not invoke wm.autoConnect()

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -127,8 +127,6 @@ void WiFi_Reconnect()
     {
         digitalWrite(LED_GN, 0);
 
-        wm.autoConnect();
-
         while (WiFi.status() != WL_CONNECTED)
         {
             delay(200);


### PR DESCRIPTION


# Description
If the ESP fails to reconnec within connect timeout it will fire up a config AP with SSID ESP_xxxxx.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [x] Lolin32
- [ ] Nodemcu32
