### PR TITLE
fix: handle state of red led correctly

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -38,6 +38,7 @@ String ShineMqtt::getId() {
 }
 
 boolean ShineMqtt::mqttEnabled() { return !this->mqttconfig.server.isEmpty(); }
+boolean ShineMqtt::mqttConnected() { return this->mqttclient.connected(); }
 
 // -------------------------------------------------------
 // Check the Mqtt status and reconnect if necessary
@@ -151,13 +152,6 @@ void ShineMqtt::onMqttMessage(char* topic, byte* payload, unsigned int length) {
 
   this->inverter.HandleCommand(command, payload, length, req, res);
   mqttPublish(res, this->mqttconfig.topic + "/result");
-}
-
-void ShineMqtt::updateMqttLed() {
-  if (!this->mqttclient.connected())
-    digitalWrite(LED_RT, 1);
-  else
-    digitalWrite(LED_RT, 0);
 }
 
 void ShineMqtt::loop() { this->mqttclient.loop(); }

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.h
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.h
@@ -25,8 +25,8 @@ class ShineMqtt {
   boolean mqttPublish(const String& JsonString);
   boolean mqttPublish(JsonDocument& doc, String topic = "");
   boolean mqttEnabled();
+  boolean mqttConnected();
   void onMqttMessage(char* topic, byte* payload, unsigned int length);
-  void updateMqttLed();
   void loop();
 
  private:

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -60,7 +60,7 @@ byte btnPressed = 0;
 #endif
 
 #define NUM_OF_RETRIES 5
-char u8RetryCounter = NUM_OF_RETRIES;
+boolean readoutSucceeded = false;
 
 uint16_t u16PacketCnt = 0;
 #if PINGER_SUPPORTED == 1
@@ -119,6 +119,25 @@ struct {
 #define CONFIG_PORTAL_MAX_TIME_SECONDS 300
 
 // -------------------------------------------------------
+// Set the red led in case of error
+// -------------------------------------------------------
+void updateRedLed() {
+    uint8_t state = 0;
+    if (!readoutSucceeded) {
+        state = 1;
+    }
+    if (Inverter.GetWiFiStickType() == Undef_stick) {
+        state = 1;
+    }
+    #if MQTT_SUPPORTED == 1
+      if (shineMqtt.mqttEnabled() && !shineMqtt.mqttConnected()) {
+        state = 1;
+      }
+    #endif
+    digitalWrite(LED_RT, state);
+}
+
+// -------------------------------------------------------
 // Check the WiFi status and reconnect if necessary
 // -------------------------------------------------------
 void WiFi_Reconnect()
@@ -143,7 +162,7 @@ void WiFi_Reconnect()
 
         Log.println(F("WiFi reconnected"));
 
-        digitalWrite(LED_RT, 1);
+        updateRedLed();
     }
 }
 
@@ -695,7 +714,6 @@ void loop()
 
     Log.loop();
     unsigned long now = millis();
-    char readoutSucceeded;
 
 #ifdef AP_BUTTON_PRESSED
     if ((now - ButtonTimer) > BUTTON_TIMER)
@@ -777,7 +795,8 @@ void loop()
     {
         if ((WiFi.status() == WL_CONNECTED) && (Inverter.GetWiFiStickType()))
         {
-            readoutSucceeded = 0;
+            uint8_t u8RetryCounter = NUM_OF_RETRIES;
+            readoutSucceeded = false;
             while ((u8RetryCounter) && !(readoutSucceeded))
             {
                 #if SIMULATE_INVERTER == 1
@@ -798,9 +817,8 @@ void loop()
                     #endif
                     handleWdtReset(mqttSuccess);
 
-                    digitalWrite(LED_RT, 0); // clear red led if everything is ok
                     // leave while-loop
-                    readoutSucceeded = 1;
+                    readoutSucceeded = true;
                 }
                 else
                 {
@@ -815,16 +833,12 @@ void loop()
                         #if MQTT_SUPPORTED == 1
                             shineMqtt.mqttPublish(String(F("{\"InverterStatus\": -1 }")));
                         #endif
-                        digitalWrite(LED_RT, 1); // set red led in case of error
                     }
                 }
             }
-            u8RetryCounter = NUM_OF_RETRIES;
         }
 
-        #if MQTT_SUPPORTED == 1
-        shineMqtt.updateMqttLed();
-        #endif
+        updateRedLed();
 
         #if PINGER_SUPPORTED == 1
             //frequently check if gateway is reachable


### PR DESCRIPTION


<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

The red led is used to indicate different error scenarious. Currently it is used for failed mqtt connection and failed mobdus readout. Each of these errors clear and set the led state individually which is not correct.

This patch changes the behavior to set it if any of the error cases is true and clears it only if all are false.

While at it also add the unknown shine wifi stick case as an error.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
