### PR TITLE
refactor: convert remaing String to const String&

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -431,8 +431,8 @@ double Growatt::getRegValue(sGrowattModbusReg_t* reg) {
   return result;
 }
 
-void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress,
-                         String Hostname) {
+void Growatt::CreateJson(ShineJsonDocument& doc, const String& MacAddress,
+                         const String& Hostname) {
   if (!Hostname.isEmpty()) {
     doc["Hostname"] = Hostname;
   }
@@ -469,7 +469,7 @@ void Growatt::CreateJson(ShineJsonDocument& doc, String MacAddress,
   }
 }
 
-void Growatt::CreateUIJson(ShineJsonDocument& doc, String Hostname) {
+void Growatt::CreateUIJson(ShineJsonDocument& doc, const String& Hostname) {
 #if SIMULATE_INVERTER != 1
   const char* unitStr[] = {"",  "W", "kWh", "V",  "A",
                            "s", "%", "Hz",  "°C", "VA"};
@@ -578,7 +578,7 @@ void Growatt::CreateUIJson(ShineJsonDocument& doc, String Hostname) {
   }
 }
 
-void Growatt::camelCaseToSnakeCase(String input, char* output) {
+void Growatt::camelCaseToSnakeCase(const String& input, char* output) {
   int outputIndex = 0;
   for (uint i = 0; input[i] != '\0'; i++) {
     if (i > 0 && isUpperCase(input[i]) &&

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -30,8 +30,9 @@ class Growatt {
   bool ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint32_t* result);
   bool WriteHoldingReg(uint16_t adr, uint16_t value);
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
-  void CreateJson(ShineJsonDocument& doc, String MacAddress, String Hostname);
-  void CreateUIJson(ShineJsonDocument& doc, String Hostname);
+  void CreateJson(ShineJsonDocument& doc, const String& MacAddress,
+                  const String& Hostname);
+  void CreateUIJson(ShineJsonDocument& doc, const String& Hostname);
   void CreateMetrics(StringStream& metrics, const String& MacAddress,
                      const String& Hostname);
 
@@ -44,7 +45,7 @@ class Growatt {
   eDevice_t _InitModbusCommunication();
   double roundByResolution(const double& value, const float& resolution);
   double getRegValue(sGrowattModbusReg_t* reg);
-  void camelCaseToSnakeCase(String input, char* output);
+  void camelCaseToSnakeCase(const String& input, char* output);
   void metricsAddValue(const String& name, double value, StringStream& metrics,
                        const String& labels);
   std::tuple<bool, String> handleEcho(const JsonDocument& req,


### PR DESCRIPTION

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Fix remaining occasions where a String is used unaltered in a function and thus avoid duplication at function call.


# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
