### PR TITLE
feat(ReadHoldingRegisters): only reread registers if they were changed

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -39,6 +39,7 @@ class Growatt {
   eDevice_t _eDevice;
   bool _GotData;
   uint32_t _PacketCnt;
+  bool _HoldingRegistersRequireUpdate;
   std::map<String, CommandHandlerFunc> handlers;
 
   eDevice_t _InitModbusCommunication();


### PR DESCRIPTION
.

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

We currently read all holding registers in every modbus read cycle. This is actually not necessary as they can only change if we write new values to them

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt MID 15 TKL3-XH

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
