### PR TITLE
fix(Modbus): reduce modbus timeout from 2000 to 250ms for 115200 baud

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -93,6 +93,7 @@ void Growatt::begin(Stream& serial) {
     delay(1000);
     Serial.begin(115200);
     Modbus.begin(1, serial);
+    Modbus.setResponseTimeout(250);
     res = Modbus.readInputRegisters(0, 1);
     if (res == Modbus.ku8MBSuccess) {
       _eDevice = ShineWiFi_X;  // USB

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
     https://github.com/dirkx/tee-log.git
-    4-20ma/ModbusMaster@^2.0.1
+    https://github.com/rob040/ModbusMaster#16d5f1f1cb4e1c9a7943425557a09ac9e89d624c
     https://github.com/bblanchon/ArduinoStreamUtils#v1.7.3
 
 


### PR DESCRIPTION
# Description

It turns out that a significant portion of modbus requests fails returning in 2000ms stalls of the ESP since the default timeout in the ModbusMaster library is hardcoded to 2000ms.

In fact I think that the timeouts are busy response messages which the ModbusMaster can't handle.

Since the ModbusMaster library has not been updated for 8 years with many PRs for adding a timeout setting change to a fork which basically is the original library plus the support for setting a timeout.

Since 115200 baud is more than 10x faster than 9600 baud its resonable to reduce the timeout from 2000ms to 250ms. In my tests the failure rate was not changed by this reduction.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X
- [X] Growatt MID 15 TKL3-XH

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
