### PR TITLE
feat(sendMetrics): improve create and transfer speed

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -33,7 +33,7 @@ class Growatt {
   void CreateJson(ShineJsonDocument& doc, const String& MacAddress,
                   const String& Hostname);
   void CreateUIJson(ShineJsonDocument& doc, const String& Hostname);
-  void CreateMetrics(StringStream& metrics, const String& MacAddress,
+  void CreateMetrics(String& metrics, const String& MacAddress,
                      const String& Hostname);
 
  private:
@@ -46,7 +46,8 @@ class Growatt {
   double roundByResolution(const double& value, const float& resolution);
   double getRegValue(sGrowattModbusReg_t* reg);
   void camelCaseToSnakeCase(const String& input, char* output);
-  void metricsAddValue(const String& name, double value, StringStream& metrics,
+  void metricsAddValue(const String& name, const double& value,
+                       const float& resolution, String& metrics,
                        const String& labels);
   std::tuple<bool, String> handleEcho(const JsonDocument& req,
                                       JsonDocument& res, Growatt& inverter);


### PR DESCRIPTION


# Description
This change improves the overall generate and transmit time for arround 100 metrics on
my ShineWifiX stick from approx. 80 ms to 50 ms.

The current implementation is slower for 3 reasons:
 - StringStream is not able to reserve memory. Thus each concat will cause realloc which even might leed to heap fragmentation.
 - The printf("%g") in Growatt::metricsAddValue seems to be an expensive operation.
 - Sending slices from a StringStream to WifiClient involves copying data.

While at it also add support for sending a 503 error if the last modbus readout failed or has not yet taken places. This avoids
that zero or outdated data is imported to prometheus.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
