### PR TITLE
feat(sendJsonSite): return 503 if modbus data is outdated or invalid

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -505,6 +505,11 @@ void sendJson(ShineJsonDocument&  doc)
 
 void sendJsonSite(void)
 {
+    if (!readoutSucceeded) {
+        httpServer.send(503, F("text/plain"), F("Service Unavailable"));
+        return;
+    }
+
     StaticJsonDocument<JSON_DOCUMENT_SIZE> doc;
     Inverter.CreateJson(doc, WiFi.macAddress(), Config.hostname);
 


### PR DESCRIPTION
# Description

Add support for sending a 503 error if the last modbus readout failed or has not yet taken places. This avoids
    that zero or outdated data is exported.


# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
