### PR TITLE
fix(setup): clear red and green led

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -359,6 +359,9 @@ void setup()
     setupWifiManagerConfigMenu();
 
     digitalWrite(LED_BL, 1);
+    digitalWrite(LED_RT, 0);
+    digitalWrite(LED_GN, 0);
+
     // Set a timeout so the ESP doesn't hang waiting to be configured, for instance after a power failure
     
     int connect_timeout_seconds = 15;


### PR DESCRIPTION


<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

ESP.restart() does not clear the outputs so red and green led might still be on.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
