### PR TITLE
feat(webUI): add metrics endpoint to the front page

### DIFF
--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -41,8 +41,9 @@ copies or substantial portions of the Software. -->
 
   <a href="./status">Json</a> -
   <a href="./uiStatus">UI Json</a> -
+  <a href="./metrics">Metrics</a> -
   <a href="./debug">Log</a> -
-  <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp">Start config access point</a> -
+  <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp">Start Config AP</a> -
   <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot">Reboot</a> -
   <a href="./postCommunicationModbus">RW Modbus</a>
 


### PR DESCRIPTION

# Description

Advertise the existence of the /metrics endpoint also on the front page of the webUI.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Inverter type e.g. Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
