### PR TITLE
feat: add /value endpoint

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -432,6 +432,22 @@ double Growatt::getRegValue(sGrowattModbusReg_t* reg) {
   return result;
 }
 
+bool Growatt::GetSingleValueByName(const String& name, double& value) {
+  for (int i = 0; i < _Protocol.InputRegisterCount; i++) {
+    if (name.equalsIgnoreCase(_Protocol.InputRegisters[i].name)) {
+      value = getRegValue(&_Protocol.InputRegisters[i]);
+      return true;
+    }
+  }
+  for (int i = 0; i < _Protocol.HoldingRegisterCount; i++) {
+    if (name.equalsIgnoreCase(_Protocol.HoldingRegisters[i].name)) {
+      value = getRegValue(&_Protocol.HoldingRegisters[i]);
+      return true;
+    }
+  }
+  return false;
+}
+
 void Growatt::CreateJson(ShineJsonDocument& doc, const String& MacAddress,
                          const String& Hostname) {
   if (!Hostname.isEmpty()) {

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -30,6 +30,7 @@ class Growatt {
   bool ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint32_t* result);
   bool WriteHoldingReg(uint16_t adr, uint16_t value);
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
+  bool GetSingleValueByName(const String& name, double& value);
   void CreateJson(ShineJsonDocument& doc, const String& MacAddress,
                   const String& Hostname);
   void CreateUIJson(ShineJsonDocument& doc, const String& Hostname);

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -122,7 +122,8 @@ copies or substantial portions of the Software. -->
                         }
                         // init dataview
                         var element = document.createElement("p");
-                        element.innerHTML = key + ": " + obj[key][0] + "&#8239;" + obj[key][1];
+                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
+                                            obj[key][0] + "&#8239;" + obj[key][1];
                         element.setAttribute("id", key);
                         container.appendChild(element);
                     }
@@ -140,7 +141,8 @@ copies or substantial portions of the Software. -->
                         }
                         // update data view
                         var element = document.getElementById(key);
-                        element.innerHTML = key + ": " + obj[key][0] + "&#8239;" + obj[key][1];
+                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
+                                            obj[key][0] + "&#8239;" + obj[key][1];
                         powerchart.update();
                     }
                 }

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -427,6 +427,7 @@ void setup()
     #ifdef ENABLE_WEB_DEBUG
         httpServer.on("/debug", sendDebug);
     #endif
+    httpServer.onNotFound(handleNotFound);
 
     Inverter.InitProtocol();
     InverterReconnect();
@@ -673,6 +674,31 @@ void handlePostData()
         httpServer.send(200, F("text/plain"), msg);
         return;
     }
+}
+
+bool sendSingleValue(void)
+{
+    if (!readoutSucceeded) {
+        httpServer.send(503, F("text/plain"), F("Service Unavailable"));
+        return true;
+    }
+    const String& key = httpServer.uri().substring(7);
+    double value;
+    if (Inverter.GetSingleValueByName(key, value)) {
+        httpServer.send(200, "text/plain", String(value));
+        return true;
+    }
+    return false;
+}
+
+void handleNotFound() {
+    if (httpServer.uri().startsWith(F("/value/")) &&
+        httpServer.uri().length() > 7) {
+        if (sendSingleValue()) {
+            return;
+        }
+    }
+    httpServer.send(404, F("text/plain"), String(F("Not found: ") + httpServer.uri()));
 }
 
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -698,7 +698,7 @@ void handleNotFound() {
             return;
         }
     }
-    httpServer.send(404, F("text/plain"), String(F("Not found: ") + httpServer.uri()));
+    httpServer.send(404, F("text/plain"), String("Not found: " + httpServer.uri()));
 }
 
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)


### PR DESCRIPTION


<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

This adds support for accessing individual register values via http without the need to request the full json or metrics output and parse it.

For example the output power can be queried via:
  http://IPAddress/value/OutputPower

I use it for accessing the inverter data from inside evcc for example which issues a new request for each value it wants to get.
# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
