### PR TITLE
refactor: remove WifiManager from global context

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -336,13 +336,6 @@ void setup()
 
     prefs.begin("ShineWifi");
 
-    #if ENABLE_DOUBLE_RESET == 1
-        if (drd->detectDoubleReset()) {
-        Log.println(F("Double reset detected"));
-            StartedConfigAfterBoot = true;
-        }
-    #endif
-
     loadConfig();
     setupWifiHost();
 
@@ -367,6 +360,13 @@ void setup()
 
     #ifdef AP_BUTTON_PRESSED
         if (AP_BUTTON_PRESSED) {
+            Log.println(F("AP Button pressed during power up"));
+            Config.force_ap = true;
+        }
+    #endif
+    #if ENABLE_DOUBLE_RESET == 1
+        if (drd->detectDoubleReset()) {
+            Log.println(F("Double reset detected"));
             Config.force_ap = true;
         }
     #endif


### PR DESCRIPTION


# Description

This moves the WifiManager from global to setup() context. This on one side saves about 500 bytes of heap. On the other side it gives the possibility to enter the config AP also by holding the AP button on power up if for whatever reason the main loop has an issue.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [x] Simulated inverter
- [X]  Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [x] Lolin32
- [ ] Nodemcu32
