### PR TITLE
fix: json document overflow

### DIFF
--- a/SRC/ShineWiFi-ModBus/GrowattTypes.h
+++ b/SRC/ShineWiFi-ModBus/GrowattTypes.h
@@ -3,7 +3,7 @@
 #include <ArduinoJson.h>
 #include <StreamUtils.h>
 
-#define JSON_DOCUMENT_SIZE 2048
+#define JSON_DOCUMENT_SIZE 4096
 #define BUFFER_SIZE 256
 
 typedef enum {


### PR DESCRIPTION
<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description
this fixes 2 issues with json document overflows.

1) when adding the active power rate to the existing implementation 2048 bytes was no longer sufficient.
2) when adding TLXH support a conditional increase of the doc size to 4096 was missing in the PR.

Change to 4096 bytes json document size unconditionally to fix both issues.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
