### PR TITLE
feat: add http command endpoint (v2)

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -30,6 +30,9 @@
 // Enable direct modbus read/write support via the WebGUI. Enabling this is a potential security issue.
 #define ENABLE_MODBUS_COMMUNICATION 0
 
+// Enable http interface to inverter commands. Enabling this is a potential security issue.
+#define ENABLE_HTTP_COMMAND_ENDPOINT 0
+
 // Define a NTP Server and TZ Info to automatically adjust the inverter date/time.
 // TZ Info can be found at: https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
 #define DEFAULT_NTP_SERVER "europe.pool.ntp.org"


### PR DESCRIPTION

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

currently inverter commands are only accessible via MQTT.

This adds a http endpoint /command to the webserver to access the inverter commands.

You may invoke /command/list for a list of commands. All commands must be executed as HTTP POST with JSON encoded parameters in the body. Additionally the Content-Type of the body must be application/json to avoid CORS attacks.

As this feature is a potential security issue it has to be explicitly enabled in the config.

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt 3000 TL-X

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
