### PR TITLE
fix(GrowattTLXH): RealOutputPercent can be negative

### DIFF
--- a/SRC/ShineWiFi-ModBus/GrowattTLXH.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattTLXH.cpp
@@ -307,7 +307,7 @@ void init_growattTLXH(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   Protocol.InputRegisters[P3000_IPF] = sGrowattModbusReg_t{
       3100, 0, SIZE_16BIT, F("InverterOutputPFNow"), 1, 1, NONE, false, false};
   Protocol.InputRegisters[P3000_REALOPPERCENT] = sGrowattModbusReg_t{
-      3101,       0,    SIZE_16BIT, F("RealOutputPercent"), 1, 1,
+      3101,       0,    SIZE_16BIT_S, F("RealOutputPercent"), 1, 1,
       PERCENTAGE, true, false};
   Protocol.InputRegisters[P3000_OPFULLWATT] = sGrowattModbusReg_t{
       3102,    0,    SIZE_32BIT, F("OutputMaxpowerLimited"), 0.1, 0.1,


### PR DESCRIPTION


# Description

if AC charing is enabled this value can become negative

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [X] Growatt MID 15 KTL3-XH

## Stick type
- [X] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
