### PR TITLE
Update platformio.yaml for build of TLXH inverters

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -46,6 +46,14 @@ jobs:
         mv .pio/build/ShineWifiS/firmware.bin release/firmware-ShineWifiS.bin
         mv .pio/build/nodemcu-32s/firmware.bin release/firmware-nodemcu-32s.bin
         mv .pio/build/d1/firmware.bin release/firmware-d1.bin
+    - name: Prepare config for TLXH inverters
+      run: |
+        sed -i -e "s/GROWATT_MODBUS_VERSION 124/GROWATT_MODBUS_VERSION 3000/g" "SRC/ShineWiFi-ModBus/Config.h"
+    - name: Run PlatformIO for TLXH inverters
+      run: pio run -e ShineWifiX
+    - name: Adjust firmware filename for TLXH inverters
+      run: |
+        mv .pio/build/ShineWifiX/firmware.bin release/firmware-ShineWifiX-TLXH.bin
     - name: Release
       uses: fnkr/github-action-ghr@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -39,6 +39,7 @@ jobs:
     - name: Run PlatformIO
       run: pio run -e ShineWifiX -e ShineWifiS -e lolin32 -e nodemcu-32s -e d1
     - name: Adjust firmware filename
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         mkdir release
         mv .pio/build/lolin32/firmware.bin release/firmware-lolin32.bin
@@ -47,13 +48,19 @@ jobs:
         mv .pio/build/nodemcu-32s/firmware.bin release/firmware-nodemcu-32s.bin
         mv .pio/build/d1/firmware.bin release/firmware-d1.bin
     - name: Prepare config for TLXH inverters
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         sed -i -e "s/GROWATT_MODBUS_VERSION 124/GROWATT_MODBUS_VERSION 3000/g" "SRC/ShineWiFi-ModBus/Config.h"
     - name: Run PlatformIO for TLXH inverters
-      run: pio run -e ShineWifiX
+      if: startsWith(github.ref, 'refs/tags/')
+      run: pio run -e ShineWifiX -e lolin32 -e nodemcu-32s -e d1
     - name: Adjust firmware filename for TLXH inverters
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
+        mv .pio/build/lolin32/firmware.bin release/firmware-lolin32-TLXH.bin
         mv .pio/build/ShineWifiX/firmware.bin release/firmware-ShineWifiX-TLXH.bin
+        mv .pio/build/nodemcu-32s/firmware.bin release/firmware-nodemcu-32s-TLXH.bin
+        mv .pio/build/d1/firmware.bin release/firmware-d1-TLXH.bin
     - name: Release
       uses: fnkr/github-action-ghr@v1
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION


# Description

This adds support for building a firmware for ShineWifiX with TLXH support

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
