### PR TITLE
refactor(ShineMqtt): leave mqtt server field blank per default

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -200,7 +200,7 @@ void loadConfig()
     Config.static_gateway = prefs.getString(ConfigFiles.static_gateway, "");
     Config.static_dns = prefs.getString(ConfigFiles.static_dns, "");
 #if MQTT_SUPPORTED == 1
-    Config.mqtt.server = prefs.getString(ConfigFiles.mqtt_server, "10.1.2.3");
+    Config.mqtt.server = prefs.getString(ConfigFiles.mqtt_server, "");
     Config.mqtt.port = prefs.getString(ConfigFiles.mqtt_port, "1883");
     Config.mqtt.topic = prefs.getString(ConfigFiles.mqtt_topic, "energy/solar");
     Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user, "");


### PR DESCRIPTION

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description
i have seen various bug reports with logs that show that the stick tries to connect to an mqtt server that obviously does not exist because its the hardcoded default.

As connecting to an non-existing server will cause stalls, change the default to empty (no server).

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
