### PR TITLE
Fix disappeared modbus master repo #425

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
     https://github.com/dirkx/tee-log.git
-    https://github.com/rob040/ModbusMaster#16d5f1f1cb4e1c9a7943425557a09ac9e89d624c
+    https://github.com/OpenInverterGateway/ModbusMaster#16d5f1f1cb4e1c9a7943425557a09ac9e89d624c
     https://github.com/bblanchon/ArduinoStreamUtils#v1.7.3
 
 


### PR DESCRIPTION
<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Please include a summary of the change and which issue is fixed.

# How Has This Been Tested?

- [x] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [x] Shine X
- [x] Shine S
- [x] Lolin32
- [x] Nodemcu32
