### PR TITLE
Make Battery Power signed for Growatt SPF

### DIFF
--- a/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
@@ -81,8 +81,9 @@ void init_growattSPF(sProtocolDefinition_t& Protocol, Growatt& inverter) {
       36, 0, SIZE_32BIT, F("ACInPwr"), 0.1, 0.1, POWER_W, true, true};  // #25
   Protocol.InputRegisters[SPF_AC_INVA] = sGrowattModbusReg_t{
       38, 0, SIZE_32BIT, F("ACInVA"), 0.1, 0.1, VA, true, false};  // #26
-  Protocol.InputRegisters[SPF_BATT_PWR] = sGrowattModbusReg_t{
-      77, 0, SIZE_32BIT_S, F("BattPwr"), 0.1, 0.1, POWER_W, true, false};  // #27
+  Protocol.InputRegisters[SPF_BATT_PWR] =
+      sGrowattModbusReg_t{77,  0,       SIZE_32BIT_S, F("BattPwr"), 0.1,
+                          0.1, POWER_W, true,         false};  // #27
 
   Protocol.InputFragmentCount = 2;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 40};

--- a/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
@@ -82,7 +82,7 @@ void init_growattSPF(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   Protocol.InputRegisters[SPF_AC_INVA] = sGrowattModbusReg_t{
       38, 0, SIZE_32BIT, F("ACInVA"), 0.1, 0.1, VA, true, false};  // #26
   Protocol.InputRegisters[SPF_BATT_PWR] = sGrowattModbusReg_t{
-      77, 0, SIZE_32BIT, F("BattPwr"), 0.1, 0.1, POWER_W, true, false};  // #27
+      77, 0, SIZE_32BIT_S, F("BattPwr"), 0.1, 0.1, POWER_W, true, false};  // #27
 
   Protocol.InputFragmentCount = 2;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 40};


### PR DESCRIPTION
Probably a typo, makes negative values appear as negative.

<!--
Make sure to signoff your commit git commit -s -m "Some message".

See https://www.secondstate.io/articles/dco/ for more information
-->

# Description

Fixed signed value for BattPwr

# How Has This Been Tested?

- [ ] Not applicable

## Inverter type
- [ ] Simulated inverter
- [x] Growatt SPF 6000 Plus

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ x] Lolin32
- [ ] Nodemcu32
