### PR TITLE
Improve documentation and fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Registers of the inverter can be read or written with an web interface (`http://<ip>/postCommunicationModbus`)
 
 * The total energy is only stored in increments of 0.1 kWh in the inverter. For a small inverter, this is a large step, especially during winter.
-If the total energy is 0.199 kWh before sunset, the totoal enrgy will be reset to 0.1 kWh next morning. For this reason the "AccumulatedEnergy" field has been implemented. It returns the energy in Wh. It will be zero after every powercycle, but can be set to the value of the previous day over a http request (`http://<ip>/setAccumulatedEnergy`)
+If the total energy is 0.199 kWh before sunset, the total energy will be reset to 0.1 kWh next morning. For this reason the "AccumulatedEnergy" field has been implemented. It returns the energy in Wh. It will be zero after every powercycle, but can be set to the value of the previous day over a http request (`http://<ip>/setAccumulatedEnergy`)
 
 * MQTT can be turned off
 

--- a/Doc/MQTT.md
+++ b/Doc/MQTT.md
@@ -2,9 +2,9 @@
 
 To make use of MQTT protocol that sends data from Growatt datalogger you need a MQTT broker and MQTT integration with this broker in Home Assistant.
 
-If you don't have your own MQTT broker, than just use existing add-on in HomeAssistant. Here how you do it.
+If you don't have your own MQTT broker, then just use the existing add-on in HomeAssistant. Here is how you do it.
 
-1. Settings -> Add-ons go to Add On store and look for `Mosquitto broker`, install it. default settings will suffice.
+1. Settings -> Add-ons go to Add On store and look for `Mosquitto broker`, install it. Default settings will suffice.
 2. Start the Mosquitto add-on.
 3. Go to Settings -> Devices & services. In Integrations it will automatically suggest `MQTT` integration, create it with default settings.
 
@@ -12,7 +12,7 @@ Now let's create a user for mqtt broker to use from Growatt datalogger.
 
 1. Go to Settings -> People -> Users. Press `Add User`, username: `growatt`, password: `your password`, mark it as `local only`.
 
-Time to configure MQTT settings on Growatt datalogger. If it's already in your network go to it's IP address and press `Start config access point`,
+Time to configure MQTT settings on Growatt datalogger. If it's already in your network go to its IP address and press `Start config access point`,
 or press AP button on the datalogger (see specific info for your logger how to enable AP mode). Connect to `Growatt` network, go to <http://192.168.4.1>
 
 Choose `Setup` and set the mqtt parameters:

--- a/Doc/ShineWiFi-S/ShineWiFi-S.md
+++ b/Doc/ShineWiFi-S/ShineWiFi-S.md
@@ -81,7 +81,7 @@ You could also use the 9-Pin serial port, if you power 8V from external and take
 Add a 1k resistor between the output of the SW1 and GPIO0. So it is possible to put the device into boot mode on start up
 
 
-Updating an installed firmware is very easy using OTA the buildin config webserver (192.168.4.1):
+Updating an installed firmware is very easy using OTA the builtin config webserver (192.168.4.1):
 Use:  http://&lt;config ip&gt;/ and click on update.
 
 

--- a/Doc/ShineWiFi-X/ShineWiFi-X.md
+++ b/Doc/ShineWiFi-X/ShineWiFi-X.md
@@ -102,6 +102,6 @@ Upload of the compiled binary of the firmware. (using arduino-ide, esptool or av
 I have used a male dupont-wire pushed in place while plugging into my USB-extension cord.
 
 
-Updating an installed firmware is very easy using OTA the buildin config webserver (192.168.4.1):
+Updating an installed firmware is very easy using OTA the builtin config webserver (192.168.4.1):
 
 Use:  http://&lt;config ip&gt;/ and click on update.

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -109,6 +109,6 @@
 #endif
 
 // Enabling this will make the wifiManager available on the previously configured wifi and ip.
-// This makes it possible to reconnfigure the stick without a direct WIFI connection. This is
+// This makes it possible to reconfigure the stick without a direct WIFI connection. This is
 // a security risk as anyone could now remotely update your firmware.
 // #define KEEP_AP_CONFIG_CONNECTION 1

--- a/SRC/ShineWiFi-ModBus/Growatt305.h
+++ b/SRC/ShineWiFi-ModBus/Growatt305.h
@@ -4,7 +4,7 @@
 #include "Growatt.h"
 #include "GrowattTypes.h"
 
-// Growatt modbus protocol version 1.24 from 2020-08-04
+// Growatt MODBUS protocol V3.05 (2013-04-25)
 typedef enum {
   P305_I_STATUS = 0,
   P305_DC_POWER,


### PR DESCRIPTION
# Description

This pull requests addresses typos in the documentation and in code comments.

# How Has This Been Tested?

- [x] Not applicable

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [ ] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
