### PR TITLE
Add missing LF in log message

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt124.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt124.cpp
@@ -606,5 +606,5 @@ void init_growatt124(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   Log.print(F("init_growatt124: input registers "));
   Log.print(Protocol.InputRegisterCount);
   Log.print(F(" holding registers "));
-  Log.print(Protocol.HoldingFragmentCount);
+  Log.println(Protocol.HoldingFragmentCount);
 }


### PR DESCRIPTION
# Description

Add the missing linefeed to the following log message:

```
init_growatt124: input registers 54 holding registers 1
```

# How Has This Been Tested?

- Tested on my own stick by building new firmware, uploading it to the stick and controlling the log output.

## Inverter type
- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt 1500 TL-X

## Stick type
- [x] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
