### PR TITLE
Make log and RW modbus buttons only visible when option configured

### DIFF
--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -89,10 +89,22 @@ copies or substantial portions of the Software. -->
         <a href="./status" class="linkButton">Json</a>
         <a href="./uiStatus" class="linkButton">UI Json</a>
         <a href="./metrics" class="linkButton">Metrics</a>
+        )====="
+        #ifdef ENABLE_WEB_DEBUG
+        R"=====(
         <a href="./debug" class="linkButton">Log</a>
+        )====="
+        #endif
+        R"=====(
         <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp" class="linkButton yellow">Start Config AP</a>
         <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot" class="linkButton yellow">Reboot</a>
-        <a href="./postCommunicationModbus" class="linkButton red">RW Modbus</a>
+        )====="
+        #if ENABLE_MODBUS_COMMUNICATION == 1
+        R"=====(
+        <a href="./postCommunicationModbus" class="linkButton red">Modbus Access</a>
+        )====="
+        #endif
+        R"=====(
     </div>
 
     <div id="DataContainer"></div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Show log and RW modbus buttons on web page only if the corresponding option is configured. Avoids the confusion of users trying to use the RW modbus feature while that is not included in the compile and thus throws an error. Also added for log button.

- [ x ] I have signed-off my commits using `git commit -s -m "Some message"` ([Developer Certificate of Origin](https://www.secondstate.io/articles/dco/)).

## How Has This Been Tested?

Tested with ShineWifiX on Growatt MIN TL-XH.

## Inverter type

- [ x ] Inverter type Min 2500 TL-XH

## Stick type

- [ x ] Shine X
