### PR TITLE
Add Modbus write reliability improvements with retry and monitoring

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -94,6 +94,34 @@
 #define BUTTON_TIMER 500 //  0.5s default
 #define WDT_TIMEOUT 300 // 5 min default
 
+// Modbus Write Reliability Settings
+// Number of retry attempts for failed writes
+#define MODBUS_WRITE_RETRY_COUNT 3
+// Initial delay between retry attempts (exponential backoff)
+#define MODBUS_WRITE_RETRY_DELAY_MS 100
+// Maximum backoff delay to prevent excessive waits (2 seconds)
+#define MODBUS_MAX_BACKOFF_MS 2000
+// Delay between sequential register writes
+#define MODBUS_INTER_WRITE_DELAY_MS 100
+// Recovery delay after write failure
+#define MODBUS_RECOVERY_DELAY_MS 500
+// Timeout for modbus responses
+#define MODBUS_RESPONSE_TIMEOUT_MS 250
+// Maximum writes per second to prevent bus flooding
+#define MODBUS_MAX_WRITES_PER_SECOND 10
+// Enable automatic connection recovery after failures
+#define MODBUS_AUTO_RECOVERY_ENABLED 1
+// Auto-reset stats before uint32_t overflow
+#define MODBUS_STATISTICS_OVERFLOW_THRESHOLD 4000000000UL
+
+// Modbus Connection Recovery Settings
+// Failures before attempting recovery
+#define MODBUS_CONSECUTIVE_FAILURE_THRESHOLD 10
+// Time to wait for inverter recovery
+#define MODBUS_RECOVERY_STABILIZATION_DELAY_MS 2000
+// Time to wait after serial init
+#define MODBUS_SERIAL_STABILIZATION_DELAY_MS 100
+
 #if PINGER_SUPPORTED == 1
     #define GATEWAY_IP IPAddress(192, 168, 178, 1)
 #endif

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -34,6 +34,13 @@ Growatt::Growatt() {
   _eDevice = Undef_stick;
   _PacketCnt = 0;
 
+  // Initialize write tracking arrays to prevent undefined behavior
+  for (int i = 0; i < MODBUS_MAX_WRITES_PER_SECOND; i++) {
+    _WriteTimestamps[i] = 0;
+  }
+  _WriteTimestampIndex = 0;
+  _ConsecutiveFailures = 0;
+
   handlers = std::map<String, CommandHandlerFunc>();
 
   // register default handlers
@@ -56,6 +63,11 @@ Growatt::Growatt() {
                                        JsonDocument& res, Growatt& inverter) {
     return handleModbusSet(req, res, *this);
   });
+}
+
+// Destructor
+Growatt::~Growatt() {
+  // Destructor - currently nothing to clean up
 }
 
 void Growatt::InitProtocol() {
@@ -94,6 +106,7 @@ void Growatt::begin(Stream& serial) {
   // init communication with the inverter
   Serial.begin(9600);
   Modbus.begin(1, serial);
+  Modbus.setResponseTimeout(MODBUS_RESPONSE_TIMEOUT_MS);
   res = Modbus.readInputRegisters(0, 1);
   if (res == Modbus.ku8MBSuccess) {
     _eDevice = ShineWiFi_S;  // Serial
@@ -101,7 +114,7 @@ void Growatt::begin(Stream& serial) {
     delay(1000);
     Serial.begin(115200);
     Modbus.begin(1, serial);
-    Modbus.setResponseTimeout(250);
+    Modbus.setResponseTimeout(MODBUS_RESPONSE_TIMEOUT_MS);
     res = Modbus.readInputRegisters(0, 1);
     if (res == Modbus.ku8MBSuccess) {
       _eDevice = ShineWiFi_X;  // USB
@@ -339,38 +352,152 @@ bool Growatt::ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint32_t* result) {
 
 bool Growatt::WriteHoldingReg(uint16_t adr, uint16_t value) {
 /**
- * @brief write 16b holding register
+ * @brief write 16b holding register with retry mechanism
  * @param adr address of the register
  * @param value value to write to the register
  * @returns true if successful
  */
 #if SIMULATE_INVERTER != 1
-  uint8_t res = Modbus.writeSingleRegister(adr, value);
-  if (res == Modbus.ku8MBSuccess) {
-    return true;
+  uint8_t res;
+  int retryDelay = MODBUS_WRITE_RETRY_DELAY_MS;
+
+  // Check write rate limit before proceeding
+  CheckWriteRateLimit();
+
+  // Auto-reset statistics when approaching uint32_t max to prevent overflow
+  if (_WriteAttempts > MODBUS_STATISTICS_OVERFLOW_THRESHOLD) {
+    ResetModbusStatistics();
   }
+
+  _WriteAttempts++;
+
+  for (int attempt = 0; attempt < MODBUS_WRITE_RETRY_COUNT; attempt++) {
+    res = Modbus.writeSingleRegister(adr, value);
+
+    if (res == Modbus.ku8MBSuccess) {
+      _WriteSuccesses++;
+      _ConsecutiveFailures = 0;  // Reset on success
+      return true;
+    }
+
+    // If this isn't the last attempt, add delay before retry
+    if (attempt < MODBUS_WRITE_RETRY_COUNT - 1) {
+#ifdef ENABLE_WEB_DEBUG
+      Log.printf(
+          "Modbus write to HR%d failed (attempt %d/%d), retrying in %dms...\n",
+          adr, attempt + 1, MODBUS_WRITE_RETRY_COUNT, retryDelay);
+#endif
+      delay(retryDelay);
+      // Exponential backoff with cap: double the delay for next retry
+      retryDelay = min(retryDelay * 2, (int)MODBUS_MAX_BACKOFF_MS);
+    }
+  }
+
+  // All retries failed, add recovery delay
+  _WriteFailures++;
+  _ConsecutiveFailures++;
+  _LastWriteErrorAddress = adr;
+#ifdef ENABLE_WEB_DEBUG
+  Log.printf(
+      "Modbus write to HR%d failed after %d attempts, entering recovery "
+      "delay\n",
+      adr, MODBUS_WRITE_RETRY_COUNT);
+  Log.printf(
+      "Write stats - Attempts: %d, Success: %d, Failures: %d, Success rate: "
+      "%.1f%%\n",
+      _WriteAttempts, _WriteSuccesses, _WriteFailures, GetWriteSuccessRate());
+#endif
+
+  // Try connection recovery if too many consecutive failures
+  TryConnectionRecovery();
+
+  delay(MODBUS_RECOVERY_DELAY_MS);
+
   return false;
 #else
+  _WriteAttempts++;
+  _WriteSuccesses++;
   return true;
 #endif
 }
 
 bool Growatt::WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value) {
   /**
-   * @brief write 16b holding register
-   * @param adr address of the register
-   * @param value value to write to the register
-   * @param size size of the register
+   * @brief write multiple 16b holding registers with retry mechanism
+   * @param adr address of the first register
+   * @param value array of values to write to the registers
+   * @param size number of registers to write
    * @returns true if successful
    */
-  for (int i = 0; i < size; i++) {
-    Modbus.setTransmitBuffer(i, value[i]);
+#if SIMULATE_INVERTER != 1
+  uint8_t res;
+  int retryDelay = MODBUS_WRITE_RETRY_DELAY_MS;
+
+  // Check write rate limit before proceeding
+  CheckWriteRateLimit();
+
+  // Auto-reset statistics when approaching uint32_t max to prevent overflow
+  if (_WriteAttempts > MODBUS_STATISTICS_OVERFLOW_THRESHOLD) {
+    ResetModbusStatistics();
   }
-  uint8_t res = Modbus.writeMultipleRegisters(adr, size);
-  if (res == Modbus.ku8MBSuccess) {
-    return true;
+
+  _WriteAttempts++;
+
+  for (int attempt = 0; attempt < MODBUS_WRITE_RETRY_COUNT; attempt++) {
+    // Set transmit buffer for all values
+    for (int i = 0; i < size; i++) {
+      Modbus.setTransmitBuffer(i, value[i]);
+    }
+
+    res = Modbus.writeMultipleRegisters(adr, size);
+
+    if (res == Modbus.ku8MBSuccess) {
+      _WriteSuccesses++;
+      _ConsecutiveFailures = 0;  // Reset on success
+      return true;
+    }
+
+    // If this isn't the last attempt, add delay before retry
+    if (attempt < MODBUS_WRITE_RETRY_COUNT - 1) {
+#ifdef ENABLE_WEB_DEBUG
+      Log.printf(
+          "Modbus write to HR%d-%d failed (attempt %d/%d), retrying in "
+          "%dms...\n",
+          adr, adr + size - 1, attempt + 1, MODBUS_WRITE_RETRY_COUNT,
+          retryDelay);
+#endif
+      delay(retryDelay);
+      // Exponential backoff with cap: double the delay for next retry
+      retryDelay = min(retryDelay * 2, (int)MODBUS_MAX_BACKOFF_MS);
+    }
   }
+
+  // All retries failed, add recovery delay
+  _WriteFailures++;
+  _ConsecutiveFailures++;
+  _LastWriteErrorAddress = adr;
+#ifdef ENABLE_WEB_DEBUG
+  Log.printf(
+      "Modbus write to HR%d-%d failed after %d attempts, entering recovery "
+      "delay\n",
+      adr, adr + size - 1, MODBUS_WRITE_RETRY_COUNT);
+  Log.printf(
+      "Write stats - Attempts: %d, Success: %d, Failures: %d, Success rate: "
+      "%.1f%%\n",
+      _WriteAttempts, _WriteSuccesses, _WriteFailures, GetWriteSuccessRate());
+#endif
+
+  // Try connection recovery if too many consecutive failures
+  TryConnectionRecovery();
+
+  delay(MODBUS_RECOVERY_DELAY_MS);
+
   return false;
+#else
+  _WriteAttempts++;
+  _WriteSuccesses++;
+  return true;
+#endif
 }
 
 bool Growatt::ReadInputReg(uint16_t adr, uint16_t* result) {
@@ -715,6 +842,17 @@ void Growatt::CreateMetrics(String& metrics, const String& MacAddress,
   metricsAddValue("HeapFragmentation", ESP.getHeapFragmentation(), 1, metrics,
                   labels);
 #endif
+
+  // Modbus health metrics
+  metricsAddValue("ModbusWriteAttempts", _WriteAttempts, 1, metrics, labels);
+  metricsAddValue("ModbusWriteSuccesses", _WriteSuccesses, 1, metrics, labels);
+  metricsAddValue("ModbusWriteFailures", _WriteFailures, 1, metrics, labels);
+  metricsAddValue("ModbusSuccessRate", GetWriteSuccessRate(), 0.1, metrics,
+                  labels);
+  if (_LastWriteErrorAddress > 0) {
+    metricsAddValue("ModbusLastErrorAddress", _LastWriteErrorAddress, 1,
+                    metrics, labels);
+  }
 }
 
 void Growatt::RegisterCommand(const String& command,
@@ -904,4 +1042,176 @@ std::tuple<bool, String> Growatt::handleModbusSet(const JsonDocument& req,
 #endif
 
   return std::make_tuple(true, "success");
+}
+
+bool Growatt::WriteRegisterWithVerify(uint16_t adr, uint16_t value,
+                                      const char* errorContext) {
+  /**
+   * @brief Write a register with built-in delay and optional error context
+   * @param adr Register address to write
+   * @param value Value to write
+   * @param errorContext Optional context string for error messages
+   * @returns true if successful, false otherwise
+   */
+  if (!WriteHoldingReg(adr, value)) {
+#ifdef ENABLE_WEB_DEBUG
+    if (strlen(errorContext) > 0) {
+      Log.printf("Failed to write %s to HR%d\n", errorContext, adr);
+    } else {
+      Log.printf("Failed to write to HR%d\n", adr);
+    }
+#endif
+    return false;
+  }
+
+  // Add inter-write delay to prevent bus congestion
+  delay(MODBUS_INTER_WRITE_DELAY_MS);
+  return true;
+}
+
+void Growatt::CheckWriteRateLimit() {
+  /**
+   * @brief Enforce write rate limiting to prevent bus flooding
+   * Uses a sliding window approach with millis() overflow protection
+   */
+  uint32_t now = millis();
+  uint32_t minInterWriteDelay = 1000 / MODBUS_MAX_WRITES_PER_SECOND;
+
+  // Count writes in the last second using overflow-safe arithmetic
+  uint8_t writesInLastSecond = 0;
+  for (int i = 0; i < MODBUS_MAX_WRITES_PER_SECOND; i++) {
+    // Overflow-safe check: elapsed time since timestamp
+    uint32_t elapsed = now - _WriteTimestamps[i];
+    if (elapsed < 1000) {  // Within last second (handles millis() overflow)
+      writesInLastSecond++;
+    }
+  }
+
+  // If we're at the limit, delay until oldest write expires
+  if (writesInLastSecond >= MODBUS_MAX_WRITES_PER_SECOND) {
+    uint32_t oldestElapsed = 0;
+    uint32_t oldestIdx = 0;
+
+    // Find the oldest write within the last second
+    for (int i = 0; i < MODBUS_MAX_WRITES_PER_SECOND; i++) {
+      uint32_t elapsed = now - _WriteTimestamps[i];
+      if (elapsed < 1000 && elapsed > oldestElapsed) {
+        oldestElapsed = elapsed;
+        oldestIdx = i;
+      }
+    }
+
+    // Calculate delay needed (1 second - elapsed time of oldest write)
+    if (oldestElapsed < 1000) {
+      uint32_t delayNeeded = 1000 - oldestElapsed + 1;  // +1ms for safety
+#ifdef ENABLE_WEB_DEBUG
+      Log.printf("Write rate limit reached (%d writes/sec), delaying %dms\n",
+                 MODBUS_MAX_WRITES_PER_SECOND, delayNeeded);
+#endif
+      delay(delayNeeded);
+    }
+  }
+
+  // Update last write time after any delay
+  now = millis();  // Re-read after potential delay
+
+  // Record this write in our circular buffer for statistics
+  _WriteTimestamps[_WriteTimestampIndex] = now;
+  _WriteTimestampIndex =
+      (_WriteTimestampIndex + 1) % MODBUS_MAX_WRITES_PER_SECOND;
+}
+
+void Growatt::TryConnectionRecovery() {
+/**
+ * @brief Attempt to recover Modbus connection after consecutive failures
+ * Uses exponential backoff and state tracking to avoid leaving connection
+ * inconsistent
+ */
+#if MODBUS_AUTO_RECOVERY_ENABLED && SIMULATE_INVERTER != 1
+  static uint32_t lastRecoveryAttempt = 0;
+  static uint8_t recoveryAttemptCount = 0;
+
+  // Only attempt recovery after reaching threshold and with exponential backoff
+  if (_ConsecutiveFailures >= MODBUS_CONSECUTIVE_FAILURE_THRESHOLD) {
+    uint32_t now = millis();
+    uint32_t backoffDelay = 5000 * (1 << min((int)recoveryAttemptCount,
+                                             4));  // Max 80 second backoff
+
+    // Check if enough time has passed since last recovery attempt
+    if (now - lastRecoveryAttempt < backoffDelay) {
+      return;
+    }
+
+    lastRecoveryAttempt = now;
+    recoveryAttemptCount++;
+
+#ifdef ENABLE_WEB_DEBUG
+    Log.printf(
+        "Attempting Modbus recovery (attempt #%d) after %d consecutive "
+        "failures\n",
+        recoveryAttemptCount, _ConsecutiveFailures);
+#endif
+
+    // Store original state for rollback
+    eDevice_t originalDevice = _eDevice;
+    uint32_t originalBaud = (_eDevice == ShineWiFi_S) ? 9600 : 115200;
+
+    // Give inverter time to recover from potential bus issues
+    delay(MODBUS_RECOVERY_STABILIZATION_DELAY_MS);
+
+    // Test 1: Try current configuration first with a simple read
+    uint8_t res = Modbus.readInputRegisters(0, 1);
+    if (res == Modbus.ku8MBSuccess) {
+#ifdef ENABLE_WEB_DEBUG
+      Log.println("Connection recovered at current settings");
+#endif
+      _ConsecutiveFailures = 0;  // Reset only on successful recovery
+      recoveryAttemptCount = 0;
+      return;
+    }
+
+#ifdef ENABLE_WEB_DEBUG
+    Log.println("Current settings failed, trying alternate baud rate");
+#endif
+
+    // Test 2: Try alternate baud rate
+    uint32_t alternateBaud = (originalBaud == 9600) ? 115200 : 9600;
+    eDevice_t alternateDevice =
+        (originalBaud == 9600) ? ShineWiFi_X : ShineWiFi_S;
+
+    Serial.begin(alternateBaud);
+    delay(MODBUS_SERIAL_STABILIZATION_DELAY_MS);  // Allow serial to stabilize
+    Modbus.begin(1, Serial);
+    Modbus.setResponseTimeout(MODBUS_RESPONSE_TIMEOUT_MS);
+    delay(100);
+
+    res = Modbus.readInputRegisters(0, 1);
+    if (res == Modbus.ku8MBSuccess) {
+      _eDevice = alternateDevice;
+#ifdef ENABLE_WEB_DEBUG
+      Log.printf("Connection recovered at %d baud\n", alternateBaud);
+#endif
+      _ConsecutiveFailures = 0;  // Reset only on successful recovery
+      recoveryAttemptCount = 0;
+      return;
+    }
+
+    // Recovery failed - revert to original settings to maintain consistency
+    Serial.begin(originalBaud);
+    delay(MODBUS_SERIAL_STABILIZATION_DELAY_MS);
+    Modbus.begin(1, Serial);
+    Modbus.setResponseTimeout(MODBUS_RESPONSE_TIMEOUT_MS);
+    _eDevice = originalDevice;
+
+#ifdef ENABLE_WEB_DEBUG
+    Log.printf(
+        "Recovery failed, reverted to original %d baud. Will retry with "
+        "backoff.\n",
+        originalBaud);
+#endif
+
+    // Don't reset _ConsecutiveFailures on failure - let it continue to
+    // accumulate
+  }
+#endif
 }

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -6,6 +6,7 @@
 class Growatt {
  public:
   Growatt();
+  ~Growatt();
   sProtocolDefinition_t _Protocol;
   using CommandHandlerFunc = std::function<std::tuple<bool, String>(
       const JsonDocument& req, JsonDocument& res, Growatt& inverter)>;
@@ -30,6 +31,8 @@ class Growatt {
   bool ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint32_t* result);
   bool WriteHoldingReg(uint16_t adr, uint16_t value);
   bool WriteHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* value);
+  bool WriteRegisterWithVerify(uint16_t adr, uint16_t value,
+                               const char* errorContext = "");
   bool GetSingleValueByName(const String& name, double& value);
   void CreateJson(JsonDocument& doc, const String& MacAddress,
                   const String& Hostname);
@@ -37,11 +40,39 @@ class Growatt {
   void CreateMetrics(String& metrics, const String& MacAddress,
                      const String& Hostname);
 
+  // Modbus health monitoring functions
+  uint32_t GetWriteAttempts() { return _WriteAttempts; }
+  uint32_t GetWriteSuccesses() { return _WriteSuccesses; }
+  uint32_t GetWriteFailures() { return _WriteFailures; }
+  uint32_t GetLastWriteErrorAddress() { return _LastWriteErrorAddress; }
+  float GetWriteSuccessRate() {
+    return _WriteAttempts > 0 ? (float)_WriteSuccesses / _WriteAttempts * 100.0
+                              : 0.0;
+  }
+
+  void ResetModbusStatistics() {
+    _WriteAttempts = 0;
+    _WriteSuccesses = 0;
+    _WriteFailures = 0;
+    _LastWriteErrorAddress = 0;
+  }
+
  private:
   eDevice_t _eDevice;
   bool _GotData;
   uint32_t _PacketCnt;
   std::map<String, CommandHandlerFunc> handlers;
+
+  // Modbus health monitoring
+  uint32_t _WriteAttempts = 0;
+  uint32_t _WriteSuccesses = 0;
+  uint32_t _WriteFailures = 0;
+  uint32_t _LastWriteErrorAddress = 0;
+
+  // Write burst protection
+  uint32_t _WriteTimestamps[MODBUS_MAX_WRITES_PER_SECOND] = {0};
+  uint8_t _WriteTimestampIndex = 0;
+  uint32_t _ConsecutiveFailures = 0;
 
   eDevice_t _InitModbusCommunication();
   double roundByResolution(const double& value, const float& resolution);
@@ -61,4 +92,8 @@ class Growatt {
   std::tuple<bool, String> handleModbusSet(const JsonDocument& req,
                                            JsonDocument& res,
                                            Growatt& inverter);
+
+  // Write burst protection and auto-recovery
+  void CheckWriteRateLimit();
+  void TryConnectionRecovery();
 };

--- a/SRC/ShineWiFi-ModBus/Growatt307.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt307.cpp
@@ -11,10 +11,15 @@ static bool verifyRegisters307(Growatt& inverter, uint16_t addr, uint16_t count,
                                const uint16_t* expected) {
   const int MAX_RETRIES = 3;
   const int RETRY_DELAY_MS = 50;
+  const int MAX_VERIFY_REGISTERS = 10;
+
+  // Safety check: ensure we don't exceed buffer capacity
+  if (count > MAX_VERIFY_REGISTERS || count == 0 || expected == nullptr) {
+    return false;
+  }
 
   for (int i = 0; i < MAX_RETRIES; ++i) {
-    uint16_t readback[10] = {0};   // Sufficient for our use cases
-    if (count > 10) return false;  // Safety check
+    uint16_t readback[MAX_VERIFY_REGISTERS] = {0};
 
     if (inverter.ReadHoldingRegFrag(addr, count, readback)) {
       bool match = true;
@@ -116,17 +121,18 @@ std::tuple<bool, String> updateDateTime307(const JsonDocument& req,
 
   year = year > 2000 ? year - 2000 : 0;
 
-  uint16_t values[] = {year, month, day, hour, minute, second};
-
-  bool success = inverter.WriteHoldingRegFrag(45, 6, values);
-#else
-  bool success = true;
-#endif
-  if (success) {
-    return std::make_tuple(true, "Successfully updated date/time");
-  } else {
-    return std::make_tuple(false, "Failed to write date/time");
+  // Write date/time registers individually with delays to prevent bus
+  // congestion
+  if (!inverter.WriteRegisterWithVerify(45, year, "year") ||
+      !inverter.WriteRegisterWithVerify(46, month, "month") ||
+      !inverter.WriteRegisterWithVerify(47, day, "day") ||
+      !inverter.WriteRegisterWithVerify(48, hour, "hour") ||
+      !inverter.WriteRegisterWithVerify(49, minute, "minute") ||
+      !inverter.WriteRegisterWithVerify(50, second, "second")) {
+    return std::make_tuple(false, "Failed to write date/time registers");
   }
+#endif
+  return std::make_tuple(true, "Successfully updated date/time");
 };
 
 std::tuple<bool, String> getPowerActiveRate307(const JsonDocument& req,
@@ -176,14 +182,14 @@ std::tuple<bool, String> setExportEnable307(const JsonDocument& req,
   uint16_t currentFlag;
   if (inverter.ReadHoldingReg(122, &currentFlag)) {
     if (currentFlag != 1) {
-      if (!inverter.WriteHoldingReg(122, 1)) {
+      if (!inverter.WriteRegisterWithVerify(122, 1, "HR122 export flag")) {
         return std::make_tuple(false, "Failed to set HR122 flag");
       }
     }
   }
 
   // Set HR123 to 1000 (100% export allowed)
-  if (!inverter.WriteHoldingReg(123, 1000)) {
+  if (!inverter.WriteRegisterWithVerify(123, 1000, "export limit value")) {
     return std::make_tuple(false, "Failed to enable export");
   }
 #endif
@@ -198,14 +204,14 @@ std::tuple<bool, String> setExportDisable307(const JsonDocument& req,
   uint16_t currentFlag;
   if (inverter.ReadHoldingReg(122, &currentFlag)) {
     if (currentFlag != 1) {
-      if (!inverter.WriteHoldingReg(122, 1)) {
+      if (!inverter.WriteRegisterWithVerify(122, 1, "HR122 export flag")) {
         return std::make_tuple(false, "Failed to set HR122 flag");
       }
     }
   }
 
   // Set HR123 to 0 (0% export allowed)
-  if (!inverter.WriteHoldingReg(123, 0)) {
+  if (!inverter.WriteRegisterWithVerify(123, 0, "export limit value")) {
     return std::make_tuple(false, "Failed to disable export");
   }
 #endif
@@ -398,17 +404,21 @@ std::tuple<bool, String> setTimeSlot307(const JsonDocument& req,
   uint16_t time_start = (start_hours << 8) | start_minutes;
   uint16_t time_stop = (stop_hours << 8) | stop_minutes;
 
-  uint16_t timeslot_raw[3];
-  timeslot_raw[0] = time_start;
-  timeslot_raw[1] = time_stop;
-  timeslot_raw[2] = enabled ? 1 : 0;
-
   uint16_t timeslot_start_addr = startReg + ((slot - 1) * 3);
-  if (!inverter.WriteHoldingRegFrag(timeslot_start_addr, 3, timeslot_raw)) {
-    return std::make_tuple(false, "Failed to write timeslot");
+
+  // Write timeslot registers individually with delays to prevent bus congestion
+  if (!inverter.WriteRegisterWithVerify(timeslot_start_addr, time_start,
+                                        "timeslot start time") ||
+      !inverter.WriteRegisterWithVerify(timeslot_start_addr + 1, time_stop,
+                                        "timeslot stop time") ||
+      !inverter.WriteRegisterWithVerify(
+          timeslot_start_addr + 2, enabled ? 1 : 0, "timeslot enabled flag")) {
+    return std::make_tuple(false, "Failed to write timeslot registers");
   }
 
   // Verify the write succeeded
+  uint16_t timeslot_raw[3] = {time_start, time_stop,
+                              enabled ? (uint16_t)1 : (uint16_t)0};
   if (!verifyRegisters307(inverter, timeslot_start_addr, 3, timeslot_raw)) {
     return std::make_tuple(false, "Timeslot verify failed");
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

I have implemented this change because of issues that are happening when using modbus writes very often (I control  inverter mode many times per hour depending on local load and 15-minute electricity spot prices). Before this change when setting multiple registers at once the inverter sometimes got to a state where no further modbus writes were accepted and they just failed. Only way to reset this was to reboot the ShineWifiX stick. 

Features:
- Implement retry mechanism with exponential backoff (capped at 2 seconds)
- Add write burst protection with configurable rate limiting
- Add Modbus health monitoring and statistics (attempts, successes, failures)
- Implement automatic connection recovery after consecutive failures
- Add millis() overflow-safe timestamp handling

Configuration:
- MODBUS_WRITE_RETRY_COUNT: Number of retry attempts (default: 3)
- MODBUS_WRITE_RETRY_DELAY_MS: Initial retry delay (default: 100ms)
- MODBUS_MAX_BACKOFF_MS: Maximum backoff delay (default: 2000ms)
- MODBUS_MAX_WRITES_PER_SECOND: Write rate limit (default: 10)
- MODBUS_AUTO_RECOVERY_ENABLED: Enable auto-recovery (default: 1)
- MODBUS_STATISTICS_OVERFLOW_THRESHOLD: Auto-reset threshold

Improvements:
- Individual register writes with inter-write delays for better compatibility
- Export Modbus health metrics via Prometheus endpoint

Build tested on all platforms:
- ESP8266: ShineWifiX, ShineWifiS, d1
- ESP32: lolin32, nodemcu-32s

## How Has This Been Tested?

- [ ] Currently being tested on my inverter 

## Inverter type

- [ ] Simulated inverter
- [ ] Inverter type e.g. Growatt SPH 10k BH UP-BL

## Stick type

- [x] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
