### PR TITLE
bugfix: setting hostname on esp8266 not working properly

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -299,8 +299,15 @@ void setupGPIO() {
 }
 
 void setupWifiHost() {
+#ifdef ESP32
+  // ESP32 needs this here (before WiFi.mode) for core 2.0.0
   WiFi.hostname(Config.hostname);
+#endif
   WiFi.mode(WIFI_STA);  // explicitly set mode, esp defaults to STA+AP
+#ifdef ESP8266
+  // ESP8266 needs this here (after WiFi.mode)
+  WiFi.hostname(Config.hostname);
+#endif
 #if OTA_SUPPORTED == 0
   MDNS.begin(Config.hostname);
 #endif


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## Description

ESP8266 and ESP32 need different order of setting WIFI mode and hostname to function properly.

## How Has This Been Tested?

- [ ] Not applicable

## Inverter type

- [ ] Simulated inverter
- [x] Inverter type - Growatt 1500 TL-X

## Stick type

- [x] Shine X
- [ ] Shine S
- [ ] Lolin32
- [ ] Nodemcu32
