### PR TITLE
Increase ShineWiFi-X detection timeout from 250ms to 2000ms

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -101,7 +101,7 @@ void Growatt::begin(Stream& serial) {
     delay(1000);
     Serial.begin(115200);
     Modbus.begin(1, serial);
-    Modbus.setResponseTimeout(250);
+    Modbus.setResponseTimeout(2000);
     res = Modbus.readInputRegisters(0, 1);
     if (res == Modbus.ku8MBSuccess) {
       _eDevice = ShineWiFi_X;  // USB


### PR DESCRIPTION
## Summary

Raises the Modbus response timeout used during ShineWiFi-X (USB, 115200 baud) auto-detection from **250 ms** to **2000 ms** (the ModbusMaster default).

## Problem

The 250 ms timeout in `Growatt::begin()` is too aggressive when the inverter is in a fault or protected state — for example:

- `PE Abnormal` (common in Brazilian split-phase 127+127 V installs)
- Grid disconnect / waiting-for-grid
- Country-code mismatch
- Any internal protection that holds the inverter in standby

In these states the inverter still responds to Modbus, but reply latency exceeds 250 ms. Auto-detection then fails on every cycle and the firmware logs:

```
Error: Unknown Shine Stick
```

…indefinitely. The user can't read or write any register — including the very registers needed to clear the fault that put the inverter into the slow-response state in the first place. It's a chicken-and-egg lockout.

## Fix

One-line change: bump the explicit timeout to 2000 ms, matching what the ModbusMaster library uses by default and what the 9600-baud (ShineWiFi-S) detection branch effectively gets.

```diff
-    Modbus.setResponseTimeout(250);
+    Modbus.setResponseTimeout(2000);
```

## Why this is safe

- **Boot only**: the timeout only affects the one-shot auto-detection at startup. Steady-state polling uses the default and is unchanged.
- **Backward compatible**: doesn't change behavior for sticks that already detect within 250 ms.
- **No new dependencies, no new config flags, no protocol changes.**

## Verification

Reproduced on a ShineWiFi-X stick (USB-Serial chip: Exar XR21V1410) connected to a Growatt MIC inverter held in PE Abnormal:

| Timeout | Detection result | Behavior |
|---------|------------------|----------|
| 250 ms (before) | Fails every cycle | "Error: Unknown Shine Stick" loop, no Modbus access |
| 2000 ms (after) | Succeeds first try | "ShineWiFi-X (USB) found", read/write working |

After detection succeeded, the user was able to write the country-code register from the web UI to clear the PE Abnormal fault and resume generation — the entire reason for needing the firmware in the first place.

## Test plan

- [x] Verified detection succeeds on real ShineWiFi-X with inverter in PE Abnormal fault state
- [x] Verified detection still succeeds on healthy inverter (no regression)
- [x] Verified arbitrary read/write via `/postCommunicationModbus` works after detection