### PR TITLE
feat: Growatt Cloud dual-mode + Web UI overhaul + Modbus detection fix

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -22,6 +22,18 @@
 // Setting this define to 0 will disable the MQTT functionality
 #define MQTT_SUPPORTED 1
 
+// Setting this define to 1 enables Growatt Cloud forwarding.
+// Sends inverter data to server.growatt.com:5279 so ShinePhone app
+// and Growatt web portal continue working alongside local MQTT.
+// The datalogger serial is auto-detected from the stock firmware's
+// flash area, or can be entered in the GrowattConfig portal.
+#define GROWATT_CLOUD_SUPPORTED 1
+
+// Setting this define to 1 enables HTTP Basic Auth for the web UI.
+// Auth credentials are configured via the GrowattConfig portal or web UI.
+// If no credentials are set, the UI is open (backward compatible).
+#define ENABLE_WEB_AUTH 1
+
 // Enable OTA update via espota. This is mainly for development purposes and enables updates
 // of the device without physical access. Use at our own risk!
 #define OTA_SUPPORTED 0

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -92,19 +92,46 @@ void Growatt::begin(Stream& serial) {
 #else
   uint8_t res;
   // init communication with the inverter
+  // Stock firmware scans Modbus addresses, not just address 1
+  // Also needs startup delay for RS232 transceiver to stabilize
+
+  // Try ShineWiFi-S (Serial, 9600 baud) - scan addresses 1-5
   Serial.begin(9600);
-  Modbus.begin(1, serial);
-  res = Modbus.readInputRegisters(0, 1);
-  if (res == Modbus.ku8MBSuccess) {
-    _eDevice = ShineWiFi_S;  // Serial
-  } else {
-    delay(1000);
-    Serial.begin(115200);
-    Modbus.begin(1, serial);
-    Modbus.setResponseTimeout(250);
+  delay(2000);  // Wait for RS232 transceiver + inverter boot
+  for (uint8_t addr = 1; addr <= 5 && _eDevice == Undef_stick; addr++) {
+    Modbus.begin(addr, serial);
+    // Try FC04 (input registers) first
     res = Modbus.readInputRegisters(0, 1);
     if (res == Modbus.ku8MBSuccess) {
-      _eDevice = ShineWiFi_X;  // USB
+      _eDevice = ShineWiFi_S;
+      Log.printf("ShineWiFi-S found at Modbus address %d (9600 baud, FC04)\n", addr);
+      break;
+    }
+    // Try FC03 (holding registers) as fallback
+    res = Modbus.readHoldingRegisters(0, 1);
+    if (res == Modbus.ku8MBSuccess) {
+      _eDevice = ShineWiFi_S;
+      Log.printf("ShineWiFi-S found at Modbus address %d (9600 baud, FC03)\n", addr);
+      break;
+    }
+    delay(200);
+  }
+
+  // Try ShineWiFi-X (USB, 115200 baud) - scan addresses 1-5
+  if (_eDevice == Undef_stick) {
+    delay(1000);
+    Serial.begin(115200);
+    delay(500);
+    for (uint8_t addr = 1; addr <= 5 && _eDevice == Undef_stick; addr++) {
+      Modbus.begin(addr, serial);
+      Modbus.setResponseTimeout(250);
+      res = Modbus.readInputRegisters(0, 1);
+      if (res == Modbus.ku8MBSuccess) {
+        _eDevice = ShineWiFi_X;
+        Log.printf("ShineWiFi-X found at Modbus address %d (115200 baud)\n", addr);
+        break;
+      }
+      delay(200);
     }
     delay(1000);
   }

--- a/SRC/ShineWiFi-ModBus/GrowattCloud.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattCloud.cpp
@@ -1,0 +1,742 @@
+/**
+ * GrowattCloud.cpp - Growatt Cloud Protocol Sender
+ *
+ * Implements the Growatt proprietary TCP protocol to server.growatt.com:5279.
+ * Designed to be added to OpenInverterGateway or similar ESP firmware
+ * for dual-mode operation (local MQTT + Growatt cloud).
+ *
+ * Protocol: Plain TCP with XOR obfuscation (key: "Growatt", 7 bytes cycled).
+ * Header (8 bytes) is cleartext, payload is XOR'd.
+ * CRC-16 (Modbus polynomial 0xA001) computed over obfuscated payload.
+ *
+ * Message flow:
+ *   1. TCP connect -> server.growatt.com:5279
+ *   2. PING (0x16) every 3 min
+ *   3. ANNOUNCE (0x03) until ACKed
+ *   4. DATA (0x04) every 5 min with inverter register values
+ *   5. Handle IDENTIFY (0x19) and CONFIGURE (0x18) from server
+ */
+
+#include "GrowattCloud.h"
+#include <time.h>
+
+#ifdef ESP8266
+#include <ESP8266WiFi.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+#endif
+
+// ============================================================================
+// Constructor
+// ============================================================================
+
+GrowattCloud::GrowattCloud()
+    : _state(GCS_DISCONNECTED)
+    , _transactionId(1)
+    , _lastPing(0)
+    , _lastDataSend(0)
+    , _lastAnnounce(0)
+    , _lastConnectAttempt(0)
+    , _unackedCount(0)
+    , _announceAcked(false)
+    , _packetsSent(0)
+    , _packetsRecv(0)
+    , _reconnects(0)
+{
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void GrowattCloud::begin(const GrowattCloudConfig& config) {
+    _config = config;
+    if (_config.serverPort == 0) _config.serverPort = GROWATT_PORT_DEFAULT;
+    if (_config.logIntervalMin == 0) _config.logIntervalMin = 5;
+    if (_config.protocolId == 0) _config.protocolId = GROWATT_PROTO_ENC_V1;
+    if (strlen(_config.serverHost) == 0) {
+        strncpy(_config.serverHost, GROWATT_SERVER_DEFAULT, sizeof(_config.serverHost) - 1);
+    }
+    if (strlen(_config.fwVersion) == 0) {
+        strncpy(_config.fwVersion, "1.7.7.7", sizeof(_config.fwVersion) - 1);
+    }
+    _state = GCS_DISCONNECTED;
+    Serial.printf("[GrowattCloud] Initialized: server=%s:%d serial=%s proto=0x%04X\n",
+                  _config.serverHost, _config.serverPort,
+                  _config.dataloggerSerial, _config.protocolId);
+}
+
+void GrowattCloud::loop(const uint16_t* inputRegs, uint16_t numInputRegs,
+                        const uint16_t* holdingRegs, uint16_t numHoldingRegs) {
+    if (!_config.enabled) return;
+    if (strlen(_config.dataloggerSerial) == 0) return;
+
+    uint32_t now = millis();
+
+    switch (_state) {
+        case GCS_DISCONNECTED:
+        case GCS_ERROR:
+            if (now - _lastConnectAttempt >= GROWATT_CONNECT_TIMEOUT) {
+                _connect();
+            }
+            break;
+
+        case GCS_CONNECTING:
+            if (_client.connected()) {
+                _state = GCS_CONNECTED;
+                _announceAcked = false;
+                _unackedCount = 0;
+                Serial.println("[GrowattCloud] TCP connected");
+                // Send initial PING immediately
+                uint16_t len = _buildPing(_txBuf);
+                _sendPacket(_txBuf, len);
+                _lastPing = now;
+            } else if (now - _lastConnectAttempt >= GROWATT_CONNECT_TIMEOUT) {
+                _state = GCS_ERROR;
+            }
+            break;
+
+        case GCS_CONNECTED:
+            // Send ANNOUNCE, wait for ACK
+            if (now - _lastAnnounce >= GROWATT_ANNOUNCE_RETRY || _lastAnnounce == 0) {
+                uint16_t len = _buildAnnounce(_txBuf, holdingRegs, numHoldingRegs);
+                if (_sendPacket(_txBuf, len)) {
+                    _lastAnnounce = now;
+                }
+            }
+            // Check for server response
+            _handleReceived();
+            // Periodic PING
+            if (now - _lastPing >= GROWATT_PING_INTERVAL) {
+                uint16_t len = _buildPing(_txBuf);
+                _sendPacket(_txBuf, len);
+                _lastPing = now;
+            }
+            if (_announceAcked) {
+                _state = GCS_ACTIVE;
+                Serial.println("[GrowattCloud] ANNOUNCE ACKed, entering ACTIVE state");
+            }
+            break;
+
+        case GCS_ANNOUNCED:
+        case GCS_ACTIVE:
+            // Check connection
+            if (!_checkConnection()) {
+                _disconnect();
+                break;
+            }
+            // Handle incoming messages (IDENTIFY, CONFIGURE, ACKs)
+            _handleReceived();
+            // Periodic PING
+            if (now - _lastPing >= GROWATT_PING_INTERVAL) {
+                uint16_t len = _buildPing(_txBuf);
+                _sendPacket(_txBuf, len);
+                _lastPing = now;
+            }
+            // Periodic DATA report
+            if (inputRegs && numInputRegs > 0) {
+                uint32_t dataInterval = (uint32_t)_config.logIntervalMin * 60000UL;
+                if (now - _lastDataSend >= dataInterval) {
+                    uint16_t len = _buildData(_txBuf, inputRegs, numInputRegs);
+                    if (_sendPacket(_txBuf, len)) {
+                        _lastDataSend = now;
+                    }
+                }
+            }
+            // Check for too many unacked messages
+            if (_unackedCount >= GROWATT_MAX_UNACKED) {
+                Serial.println("[GrowattCloud] Too many unacked, reconnecting");
+                _disconnect();
+            }
+            break;
+    }
+}
+
+void GrowattCloud::reconnect() {
+    _disconnect();
+}
+
+void GrowattCloud::setInverterSerial(const char* serial) {
+    strncpy(_config.inverterSerial, serial, GROWATT_SERIAL_LEN);
+    _config.inverterSerial[GROWATT_SERIAL_LEN] = '\0';
+}
+
+// ============================================================================
+// Connection Management
+// ============================================================================
+
+void GrowattCloud::_connect() {
+    _lastConnectAttempt = millis();
+    Serial.printf("[GrowattCloud] Connecting to %s:%d...\n",
+                  _config.serverHost, _config.serverPort);
+
+    if (_client.connect(_config.serverHost, _config.serverPort)) {
+        _state = GCS_CONNECTED;
+        _announceAcked = false;
+        _unackedCount = 0;
+        _lastAnnounce = 0;
+        _reconnects++;
+        // Send initial PING
+        uint16_t len = _buildPing(_txBuf);
+        _sendPacket(_txBuf, len);
+        _lastPing = millis();
+    } else {
+        _state = GCS_ERROR;
+        Serial.println("[GrowattCloud] Connection failed");
+    }
+}
+
+void GrowattCloud::_disconnect() {
+    _client.stop();
+    _state = GCS_DISCONNECTED;
+    _announceAcked = false;
+    _lastAnnounce = 0;
+}
+
+bool GrowattCloud::_checkConnection() {
+    return _client.connected();
+}
+
+// ============================================================================
+// Protocol Message Builders
+// ============================================================================
+
+/**
+ * PING (0x16): Keepalive heartbeat
+ * Payload: [30B datalogger_serial][0x00][0x00]
+ * Server echoes the exact packet back.
+ */
+uint16_t GrowattCloud::_buildPing(uint8_t* buf) {
+    uint16_t dataLen = GROWATT_SERIAL_LEN + 2; // serial + 2 zero bytes
+    uint16_t totalLen = GROWATT_HEADER_LEN + dataLen + 2; // + CRC
+
+    _writeHeader(buf, _transactionId++, _config.protocolId,
+                 dataLen + 2, 0x01, GROWATT_FUNC_PING);
+
+    // Payload: serial + 0x0000
+    _writeSerial(buf + GROWATT_HEADER_LEN, _config.dataloggerSerial);
+    buf[GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN] = 0x00;
+    buf[GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN + 1] = 0x00;
+
+    // XOR-encrypt payload (not header)
+    if (_config.protocolId == GROWATT_PROTO_ENC_V1 ||
+        _config.protocolId == GROWATT_PROTO_ENC_V2) {
+        _xorEncrypt(buf, GROWATT_HEADER_LEN, dataLen);
+    }
+
+    // CRC over obfuscated payload
+    uint16_t crc = _calcCRC16(buf, GROWATT_HEADER_LEN + dataLen);
+    buf[GROWATT_HEADER_LEN + dataLen] = (crc >> 8) & 0xFF;
+    buf[GROWATT_HEADER_LEN + dataLen + 1] = crc & 0xFF;
+
+    return totalLen;
+}
+
+/**
+ * ANNOUNCE (0x03): Device announcement with inverter info
+ * Stock firmware sends identical 255-byte payload structure as DATA,
+ * just with func code 0x03 instead of 0x04.
+ * Register data area contains holding register values (or zeros).
+ */
+uint16_t GrowattCloud::_buildAnnounce(uint8_t* buf,
+                                       const uint16_t* holdingRegs,
+                                       uint16_t numHoldingRegs) {
+    const uint16_t payloadLen = 255;
+    const uint16_t payloadOffset = GROWATT_HEADER_LEN;
+    uint8_t* p = buf + payloadOffset;
+
+    // Zero the entire payload area first
+    memset(p, 0, payloadLen);
+
+    // Bytes 0-29: Datalogger serial
+    _writeSerial(p + 0, _config.dataloggerSerial);
+
+    // Bytes 30-59: Inverter serial
+    _writeSerial(p + 30, _config.inverterSerial);
+
+    // Bytes 60-65: Timestamp
+    _writeTimestamp(p + 60);
+
+    // Byte 66: Inverter type
+    p[66] = 0x02;
+
+    // Bytes 67-70: Block 1 descriptor (start=0, end=44)
+    p[67] = 0x00; p[68] = 0x00; // start register 0
+    p[69] = 0x00; p[70] = 44;   // end register 44
+
+    // Bytes 71-160: Holding registers 0-44 as sequential uint16 BE (or zeros)
+    for (uint16_t i = 0; i < 45; i++) {
+        uint16_t val = (holdingRegs && i < numHoldingRegs) ? holdingRegs[i] : 0;
+        p[71 + i * 2]     = (val >> 8) & 0xFF;
+        p[71 + i * 2 + 1] = val & 0xFF;
+    }
+
+    // Block 2 descriptor embedded at register positions 45-46
+    p[161] = 0x00; p[162] = 45;   // Block 2 start register = 45
+    p[163] = 0x00; p[164] = 89;   // Block 2 end register = 89
+
+    // Bytes 165-250: Holding registers 47-89 as sequential uint16 BE (or zeros)
+    for (uint16_t i = 47; i < 90; i++) {
+        uint16_t val = (holdingRegs && i < numHoldingRegs) ? holdingRegs[i] : 0;
+        uint16_t offset = 165 + (i - 47) * 2;
+        p[offset]     = (val >> 8) & 0xFF;
+        p[offset + 1] = val & 0xFF;
+    }
+
+    // Bytes 251-254: Zero padding (already zeroed by memset)
+
+    // Header: data_len = 257 (payload 255 + unit_id 1 + func_code 1)
+    _writeHeader(buf, _transactionId++, _config.protocolId,
+                 payloadLen + 2, 0x01, GROWATT_FUNC_ANNOUNCE);
+
+    // XOR-encrypt payload (not header)
+    if (_config.protocolId == GROWATT_PROTO_ENC_V1 ||
+        _config.protocolId == GROWATT_PROTO_ENC_V2) {
+        _xorEncrypt(buf, payloadOffset, payloadLen);
+    }
+
+    // CRC over header + XOR'd payload
+    uint16_t crc = _calcCRC16(buf, payloadOffset + payloadLen);
+    buf[payloadOffset + payloadLen]     = (crc >> 8) & 0xFF;
+    buf[payloadOffset + payloadLen + 1] = crc & 0xFF;
+
+    return payloadOffset + payloadLen + 2; // 8 + 255 + 2 = 265
+}
+
+/**
+ * DATA (0x04): Periodic inverter telemetry report
+ * Verified stock firmware format: 265 bytes total (8 header + 255 payload + 2 CRC)
+ * Payload layout (255 bytes, fixed size):
+ *   [0-29]    Datalogger serial (30B NUL-padded)
+ *   [30-59]   Inverter serial (30B NUL-padded)
+ *   [60-65]   Timestamp (6x uint8: Y-2000, M, D, H, M, S)
+ *   [66]      Inverter type = 0x02
+ *   [67-68]   Block 1 start register = 0 (uint16 BE)
+ *   [69-70]   Block 1 end register = 44 (uint16 BE)
+ *   [71-160]  FC04 input registers 0-44 (45 x 2 = 90 bytes, uint16 BE)
+ *   [161-162] Block 2 start register = 45 (embedded at reg positions 45-46)
+ *   [163-164] Block 2 end register = 89 (embedded at reg positions 45-46)
+ *   [165-250] FC04 input registers 47-89 (43 x 2 = 86 bytes, uint16 BE)
+ *   [251-254] Zero padding
+ * data_len field = 257 (255 payload + 2 for unit_id + func_code)
+ */
+uint16_t GrowattCloud::_buildData(uint8_t* buf,
+                                   const uint16_t* inputRegs,
+                                   uint16_t numInputRegs) {
+    const uint16_t payloadLen = 255;
+    const uint16_t payloadOffset = GROWATT_HEADER_LEN;
+    uint8_t* p = buf + payloadOffset;
+
+    // Zero the entire payload area first
+    memset(p, 0, payloadLen);
+
+    // Bytes 0-29: Datalogger serial
+    _writeSerial(p + 0, _config.dataloggerSerial);
+
+    // Bytes 30-59: Inverter serial
+    _writeSerial(p + 30, _config.inverterSerial);
+
+    // Bytes 60-65: Timestamp
+    _writeTimestamp(p + 60);
+
+    // Byte 66: Inverter type
+    p[66] = 0x02;
+
+    // Bytes 67-70: Block 1 descriptor (start=0, end=44)
+    p[67] = 0x00; p[68] = 0x00; // start register 0
+    p[69] = 0x00; p[70] = 44;   // end register 44
+
+    // Bytes 71-160: Input registers 0-44 as sequential uint16 BE (45 regs = 90 bytes)
+    for (uint16_t i = 0; i < 45; i++) {
+        uint16_t val = (i < numInputRegs) ? inputRegs[i] : 0;
+        p[71 + i * 2]     = (val >> 8) & 0xFF;
+        p[71 + i * 2 + 1] = val & 0xFF;
+    }
+    // Note: At byte offsets 161-164 (register positions 45 and 46 in the stream),
+    // the stock firmware embeds block 2 descriptor values (45 and 89).
+    // These occupy the same positions as inputRegs[45] and inputRegs[46] would.
+    p[161] = 0x00; p[162] = 45;   // Block 2 start register = 45
+    p[163] = 0x00; p[164] = 89;   // Block 2 end register = 89
+
+    // Bytes 165-250: Input registers 47-89 as sequential uint16 BE (43 regs = 86 bytes)
+    for (uint16_t i = 47; i < 90; i++) {
+        uint16_t val = (i < numInputRegs) ? inputRegs[i] : 0;
+        uint16_t offset = 165 + (i - 47) * 2;
+        p[offset]     = (val >> 8) & 0xFF;
+        p[offset + 1] = val & 0xFF;
+    }
+
+    // Bytes 251-254: Zero padding (already zeroed by memset)
+
+    // Header: data_len = 257 (payload 255 + unit_id 1 + func_code 1)
+    _writeHeader(buf, _transactionId++, _config.protocolId,
+                 payloadLen + 2, 0x01, GROWATT_FUNC_DATA);
+
+    // XOR-encrypt payload (not header)
+    if (_config.protocolId == GROWATT_PROTO_ENC_V1 ||
+        _config.protocolId == GROWATT_PROTO_ENC_V2) {
+        _xorEncrypt(buf, payloadOffset, payloadLen);
+    }
+
+    // CRC over header + XOR'd payload
+    uint16_t crc = _calcCRC16(buf, payloadOffset + payloadLen);
+    buf[payloadOffset + payloadLen]     = (crc >> 8) & 0xFF;
+    buf[payloadOffset + payloadLen + 1] = crc & 0xFF;
+
+    return payloadOffset + payloadLen + 2; // 8 + 255 + 2 = 265
+}
+
+// ============================================================================
+// Receive Handler
+// ============================================================================
+
+void GrowattCloud::_handleReceived() {
+    if (!_client.available()) return;
+
+    int len = _readPacket(_rxBuf, GROWATT_MAX_PACKET);
+    if (len < GROWATT_HEADER_LEN) return;
+
+    _packetsRecv++;
+
+    uint8_t funcCode = _rxBuf[7];
+
+    // Decrypt payload if encrypted protocol
+    uint16_t protoId = (_rxBuf[2] << 8) | _rxBuf[3];
+    if (protoId == GROWATT_PROTO_ENC_V1 || protoId == GROWATT_PROTO_ENC_V2) {
+        _xorDecrypt(_rxBuf, GROWATT_HEADER_LEN, len - GROWATT_HEADER_LEN);
+    }
+
+    switch (funcCode) {
+        case GROWATT_FUNC_PING:
+            // PING echo from server - connection is alive
+            break;
+
+        case GROWATT_FUNC_ANNOUNCE:
+            // ACK for our ANNOUNCE
+            _handleAck(GROWATT_FUNC_ANNOUNCE);
+            break;
+
+        case GROWATT_FUNC_DATA:
+            // ACK for our DATA
+            _handleAck(GROWATT_FUNC_DATA);
+            break;
+
+        case GROWATT_FUNC_IDENTIFY:
+            // Server is querying our configuration
+            _handleIdentify(_rxBuf, len);
+            break;
+
+        case GROWATT_FUNC_CONFIGURE:
+            // Server is pushing configuration changes
+            _handleConfigure(_rxBuf, len);
+            break;
+
+        default:
+            Serial.printf("[GrowattCloud] Unknown func 0x%02X, len=%d\n", funcCode, len);
+            break;
+    }
+}
+
+void GrowattCloud::_handleAck(uint8_t funcCode) {
+    if (_unackedCount > 0) _unackedCount--;
+
+    if (funcCode == GROWATT_FUNC_ANNOUNCE) {
+        _announceAcked = true;
+        Serial.println("[GrowattCloud] ANNOUNCE ACK received");
+    } else if (funcCode == GROWATT_FUNC_DATA) {
+        Serial.println("[GrowattCloud] DATA ACK received");
+    }
+}
+
+/**
+ * Handle IDENTIFY (0x19) queries from server.
+ * Server asks for specific config items; we must respond honestly.
+ *
+ * CRITICAL: For config item 0x13 (server address), ALWAYS respond
+ * with "server.growatt.com" even if we're running locally. Otherwise
+ * the server force-reconfigures and reboots us.
+ */
+void GrowattCloud::_handleIdentify(const uint8_t* data, uint16_t len) {
+    if (len < GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN + 4) return;
+
+    uint16_t payloadStart = GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN;
+    uint16_t configItem = (data[payloadStart] << 8) | data[payloadStart + 1];
+
+    Serial.printf("[GrowattCloud] IDENTIFY query: config item 0x%04X\n", configItem);
+
+    // Build response
+    uint16_t pos = GROWATT_HEADER_LEN;
+
+    // Echo datalogger serial
+    _writeSerial(_txBuf + pos, _config.dataloggerSerial);
+    pos += GROWATT_SERIAL_LEN;
+
+    // Config item
+    _txBuf[pos++] = (configItem >> 8) & 0xFF;
+    _txBuf[pos++] = configItem & 0xFF;
+
+    // Value depends on config item
+    switch (configItem) {
+        case GROWATT_CFG_INTERVAL: {
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x01; // length = 1
+            _txBuf[pos++] = _config.logIntervalMin;
+            break;
+        }
+        case GROWATT_CFG_ADDR_MIN: {
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x01;
+            _txBuf[pos++] = 1; // Modbus addr min
+            break;
+        }
+        case GROWATT_CFG_ADDR_MAX: {
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x01;
+            _txBuf[pos++] = 1; // Modbus addr max (single inverter)
+            break;
+        }
+        case GROWATT_CFG_DATALOGGER_ID: {
+            uint8_t slen = strlen(_config.dataloggerSerial);
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = slen;
+            memcpy(_txBuf + pos, _config.dataloggerSerial, slen);
+            pos += slen;
+            break;
+        }
+        case GROWATT_CFG_LOCAL_IP: {
+            String ip = WiFi.localIP().toString();
+            uint8_t slen = ip.length();
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = slen;
+            memcpy(_txBuf + pos, ip.c_str(), slen);
+            pos += slen;
+            break;
+        }
+        case GROWATT_CFG_LOCAL_PORT: {
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x04;
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x00;
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x00;
+            break;
+        }
+        case GROWATT_CFG_MAC: {
+            String mac = WiFi.macAddress(); // "AA:BB:CC:DD:EE:FF"
+            uint8_t slen = mac.length();
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = slen;
+            memcpy(_txBuf + pos, mac.c_str(), slen);
+            pos += slen;
+            break;
+        }
+        case GROWATT_CFG_SERVER_LEN: {
+            // Length of server hostname
+            uint8_t slen = strlen(GROWATT_SERVER_DEFAULT);
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x01;
+            _txBuf[pos++] = slen;
+            break;
+        }
+        case GROWATT_CFG_SERVER_PORT: {
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x04;
+            uint32_t port = GROWATT_PORT_DEFAULT;
+            _txBuf[pos++] = (port >> 24) & 0xFF;
+            _txBuf[pos++] = (port >> 16) & 0xFF;
+            _txBuf[pos++] = (port >> 8) & 0xFF;
+            _txBuf[pos++] = port & 0xFF;
+            break;
+        }
+        case GROWATT_CFG_SERVER_ADDR: {
+            // CRITICAL: Always respond with the official server address!
+            // If we respond with anything else, server pushes a reconfig + reboot.
+            const char* official = GROWATT_SERVER_DEFAULT;
+            uint8_t slen = strlen(official);
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = slen;
+            memcpy(_txBuf + pos, official, slen);
+            pos += slen;
+            break;
+        }
+        case GROWATT_CFG_FW_VERSION: {
+            uint8_t slen = strlen(_config.fwVersion);
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = slen;
+            memcpy(_txBuf + pos, _config.fwVersion, slen);
+            pos += slen;
+            break;
+        }
+        default: {
+            // Unknown config item - respond with empty
+            _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x00;
+            break;
+        }
+    }
+
+    uint16_t dataLen = pos - GROWATT_HEADER_LEN;
+    _writeHeader(_txBuf, _transactionId++, _config.protocolId,
+                 dataLen + 2, 0x01, GROWATT_FUNC_IDENTIFY);
+
+    if (_config.protocolId == GROWATT_PROTO_ENC_V1 ||
+        _config.protocolId == GROWATT_PROTO_ENC_V2) {
+        _xorEncrypt(_txBuf, GROWATT_HEADER_LEN, dataLen);
+    }
+
+    uint16_t crc = _calcCRC16(_txBuf, GROWATT_HEADER_LEN + dataLen);
+    _txBuf[pos++] = (crc >> 8) & 0xFF;
+    _txBuf[pos++] = crc & 0xFF;
+
+    _sendPacket(_txBuf, pos);
+}
+
+/**
+ * Handle CONFIGURE (0x18) from server.
+ * Always ACK (0x00) to prevent server from retrying.
+ * Ignore actual config changes since we manage our own config.
+ *
+ * Special case: 0x20 = reboot command. We ACK but do NOT reboot.
+ */
+void GrowattCloud::_handleConfigure(const uint8_t* data, uint16_t len) {
+    if (len < GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN + 4) return;
+
+    uint16_t payloadStart = GROWATT_HEADER_LEN + GROWATT_SERIAL_LEN;
+    uint16_t configItem = (data[payloadStart] << 8) | data[payloadStart + 1];
+
+    Serial.printf("[GrowattCloud] CONFIGURE push: item 0x%04X (ACKing, ignoring)\n",
+                  configItem);
+
+    // Build ACK response: [header][serial][config_item][0x00 0x01][0x00]
+    uint16_t pos = GROWATT_HEADER_LEN;
+    _writeSerial(_txBuf + pos, _config.dataloggerSerial);
+    pos += GROWATT_SERIAL_LEN;
+    _txBuf[pos++] = (configItem >> 8) & 0xFF;
+    _txBuf[pos++] = configItem & 0xFF;
+    _txBuf[pos++] = 0x00; _txBuf[pos++] = 0x01; // length = 1
+    _txBuf[pos++] = 0x00; // ACK = success
+
+    uint16_t dataLen = pos - GROWATT_HEADER_LEN;
+    _writeHeader(_txBuf, _transactionId++, _config.protocolId,
+                 dataLen + 2, 0x01, GROWATT_FUNC_CONFIGURE);
+
+    if (_config.protocolId == GROWATT_PROTO_ENC_V1 ||
+        _config.protocolId == GROWATT_PROTO_ENC_V2) {
+        _xorEncrypt(_txBuf, GROWATT_HEADER_LEN, dataLen);
+    }
+
+    uint16_t crc = _calcCRC16(_txBuf, GROWATT_HEADER_LEN + dataLen);
+    _txBuf[pos++] = (crc >> 8) & 0xFF;
+    _txBuf[pos++] = crc & 0xFF;
+
+    _sendPacket(_txBuf, pos);
+}
+
+// ============================================================================
+// Header, Encryption, CRC
+// ============================================================================
+
+void GrowattCloud::_writeHeader(uint8_t* buf, uint16_t transId, uint16_t protoId,
+                                 uint16_t dataLen, uint8_t unitId, uint8_t funcCode) {
+    buf[0] = (transId >> 8) & 0xFF;
+    buf[1] = transId & 0xFF;
+    buf[2] = (protoId >> 8) & 0xFF;
+    buf[3] = protoId & 0xFF;
+    buf[4] = (dataLen >> 8) & 0xFF;
+    buf[5] = dataLen & 0xFF;
+    buf[6] = unitId;
+    buf[7] = funcCode;
+}
+
+void GrowattCloud::_xorEncrypt(uint8_t* data, uint16_t offset, uint16_t len) {
+    for (uint16_t i = 0; i < len; i++) {
+        data[offset + i] ^= GROWATT_XOR_MASK[i % GROWATT_XOR_MASK_LEN];
+    }
+}
+
+void GrowattCloud::_xorDecrypt(uint8_t* data, uint16_t offset, uint16_t len) {
+    // XOR is its own inverse
+    _xorEncrypt(data, offset, len);
+}
+
+/**
+ * Modbus CRC-16 (polynomial 0xA001)
+ */
+uint16_t GrowattCloud::_calcCRC16(const uint8_t* data, uint16_t len) {
+    uint16_t crc = 0xFFFF;
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (uint8_t j = 0; j < 8; j++) {
+            if (crc & 0x0001) {
+                crc = (crc >> 1) ^ 0xA001;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+void GrowattCloud::_writeSerial(uint8_t* buf, const char* serial) {
+    memset(buf, 0, GROWATT_SERIAL_LEN);
+    if (serial) {
+        uint8_t len = strlen(serial);
+        if (len > GROWATT_SERIAL_LEN) len = GROWATT_SERIAL_LEN;
+        memcpy(buf, serial, len);
+    }
+}
+
+void GrowattCloud::_writeTimestamp(uint8_t* buf) {
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+
+    // Timestamp: 6 single bytes (NOT 2-byte shorts)
+    buf[0] = (uint8_t)(timeinfo.tm_year + 1900 - 2000); // Year - 2000
+    buf[1] = (uint8_t)(timeinfo.tm_mon + 1);             // Month 1-12
+    buf[2] = (uint8_t)(timeinfo.tm_mday);                // Day 1-31
+    buf[3] = (uint8_t)(timeinfo.tm_hour);                // Hour 0-23
+    buf[4] = (uint8_t)(timeinfo.tm_min);                 // Minute 0-59
+    buf[5] = (uint8_t)(timeinfo.tm_sec);                 // Second 0-59
+}
+
+// ============================================================================
+// Send / Receive Helpers
+// ============================================================================
+
+bool GrowattCloud::_sendPacket(uint8_t* buf, uint16_t len) {
+    if (!_client.connected()) return false;
+
+    size_t written = _client.write(buf, len);
+    if (written == len) {
+        _packetsSent++;
+        _unackedCount++;
+        return true;
+    }
+    Serial.printf("[GrowattCloud] Send failed: wrote %d/%d\n", written, len);
+    return false;
+}
+
+int GrowattCloud::_readPacket(uint8_t* buf, uint16_t maxLen) {
+    if (!_client.available()) return 0;
+
+    // Read header first (8 bytes)
+    int headerRead = 0;
+    uint32_t start = millis();
+    while (headerRead < GROWATT_HEADER_LEN && millis() - start < GROWATT_READ_TIMEOUT) {
+        if (_client.available()) {
+            buf[headerRead++] = _client.read();
+        } else {
+            delay(1);
+        }
+    }
+    if (headerRead < GROWATT_HEADER_LEN) return headerRead;
+
+    // Extract data length from header
+    uint16_t dataLen = (buf[4] << 8) | buf[5];
+    if (dataLen > maxLen - GROWATT_HEADER_LEN) {
+        // Packet too large, drain and discard
+        while (_client.available()) _client.read();
+        return GROWATT_HEADER_LEN;
+    }
+
+    // Read remaining data
+    int dataRead = 0;
+    start = millis();
+    while (dataRead < dataLen && millis() - start < GROWATT_READ_TIMEOUT) {
+        if (_client.available()) {
+            buf[GROWATT_HEADER_LEN + dataRead++] = _client.read();
+        } else {
+            delay(1);
+        }
+    }
+
+    return GROWATT_HEADER_LEN + dataRead;
+}

--- a/SRC/ShineWiFi-ModBus/GrowattCloud.h
+++ b/SRC/ShineWiFi-ModBus/GrowattCloud.h
@@ -1,0 +1,197 @@
+/**
+ * GrowattCloud.h - Growatt Cloud Protocol Sender for OpenInverterGateway
+ *
+ * Implements the Growatt proprietary TCP protocol (port 5279) to send
+ * inverter data to server.growatt.com while simultaneously publishing
+ * to MQTT/Prometheus locally. This enables dual-mode operation:
+ * local monitoring + Growatt app/cloud access.
+ *
+ * Protocol details reverse-engineered from stock ShineWiFi-S firmware
+ * and community documentation (Grott, nwf, sciurius).
+ *
+ * Author: OpenInverterGateway contributors
+ * Date: 2026-05-19
+ * License: MIT
+ */
+
+#ifndef GROWATT_CLOUD_H
+#define GROWATT_CLOUD_H
+
+#include <Arduino.h>
+#include <WiFiClient.h>
+
+// --- Protocol Constants ---
+#define GROWATT_SERVER_DEFAULT    "server.growatt.com"
+#define GROWATT_PORT_DEFAULT      5279
+
+// Protocol IDs (bytes 2-3 of header)
+#define GROWATT_PROTO_PLAIN       0x0000  // Modbus standard, no encryption
+#define GROWATT_PROTO_V3          0x0002  // Growatt v3.x, no encryption
+#define GROWATT_PROTO_ENC_V1      0x0005  // Growatt encrypted v1 (XOR)
+#define GROWATT_PROTO_ENC_V2      0x0006  // Growatt encrypted v2 (XOR)
+
+// Function codes (byte 7 of header)
+#define GROWATT_FUNC_ANNOUNCE     0x03   // DATA3: device announcement
+#define GROWATT_FUNC_DATA         0x04   // DATA4: periodic telemetry
+#define GROWATT_FUNC_PING         0x16   // Keepalive heartbeat
+#define GROWATT_FUNC_CONFIGURE    0x18   // Server pushes config
+#define GROWATT_FUNC_IDENTIFY     0x19   // Server queries config
+#define GROWATT_FUNC_SMARTMETER   0x20   // Smart meter data
+
+// Identify config items (for responding to server queries)
+#define GROWATT_CFG_INTERVAL      0x04   // Log interval (minutes)
+#define GROWATT_CFG_ADDR_MIN      0x05   // Modbus address range min
+#define GROWATT_CFG_ADDR_MAX      0x06   // Modbus address range max
+#define GROWATT_CFG_DATALOGGER_ID 0x08   // Datalogger serial
+#define GROWATT_CFG_LOCAL_IP      0x0E   // Local IP address
+#define GROWATT_CFG_LOCAL_PORT    0x0F   // Local port
+#define GROWATT_CFG_MAC           0x10   // MAC address
+#define GROWATT_CFG_SERVER_LEN    0x11   // Server hostname length
+#define GROWATT_CFG_SERVER_PORT   0x12   // Server port
+#define GROWATT_CFG_SERVER_ADDR   0x13   // Server address (ENFORCED!)
+#define GROWATT_CFG_FW_VERSION    0x15   // Firmware version string
+
+// Timing (milliseconds)
+#define GROWATT_PING_INTERVAL     180000  // 3 minutes
+#define GROWATT_DATA_INTERVAL     300000  // 5 minutes (configurable)
+#define GROWATT_ANNOUNCE_RETRY    30000   // 30 seconds until ACKed
+#define GROWATT_CONNECT_TIMEOUT   10000   // TCP connect timeout
+#define GROWATT_READ_TIMEOUT      5000    // TCP read timeout
+#define GROWATT_MAX_UNACKED       15      // Drop connection after N unacked
+
+// Buffer sizes
+#define GROWATT_SERIAL_LEN        30      // Serial field width (NUL-padded)
+#define GROWATT_HEADER_LEN        8       // Protocol header size
+#define GROWATT_MAX_PACKET        512     // Max packet size
+#define GROWATT_TIMESTAMP_LEN     6       // 6 single bytes: Y-2000, M, D, H, M, S
+
+// XOR encryption mask
+static const uint8_t GROWATT_XOR_MASK[] = { 0x47, 0x72, 0x6F, 0x77, 0x61, 0x74, 0x74 };
+#define GROWATT_XOR_MASK_LEN      7
+
+// --- Structures ---
+
+struct GrowattCloudConfig {
+    char     serverHost[64];
+    uint16_t serverPort;
+    char     dataloggerSerial[GROWATT_SERIAL_LEN + 1]; // Read from config portal
+    char     inverterSerial[GROWATT_SERIAL_LEN + 1];   // Read from inverter via Modbus
+    char     fwVersion[16];
+    uint8_t  logIntervalMin;      // Data report interval in minutes
+    uint16_t protocolId;          // 0x0005 for encrypted v1
+    bool     enabled;             // Enable/disable cloud sending
+};
+
+// Connection state machine
+enum GrowattCloudState {
+    GCS_DISCONNECTED,
+    GCS_CONNECTING,
+    GCS_CONNECTED,
+    GCS_ANNOUNCED,       // ANNOUNCE sent, waiting for ACK
+    GCS_ACTIVE,          // ACK received, sending periodic DATA
+    GCS_ERROR
+};
+
+class GrowattCloud {
+public:
+    GrowattCloud();
+
+    /**
+     * Initialize with configuration.
+     * Call once in setup() after reading config from portal/EEPROM.
+     */
+    void begin(const GrowattCloudConfig& config);
+
+    /**
+     * Call in loop(). Handles connection, ping, announce, data sending.
+     * Pass current inverter register data for periodic reports.
+     *
+     * @param inputRegs   Array of input register values (FC04, from inverter)
+     * @param numInputRegs Number of input registers
+     * @param holdingRegs  Array of holding register values (FC03, from inverter)
+     * @param numHoldingRegs Number of holding registers
+     */
+    void loop(const uint16_t* inputRegs, uint16_t numInputRegs,
+              const uint16_t* holdingRegs = nullptr, uint16_t numHoldingRegs = 0);
+
+    /**
+     * Check if connected and active.
+     */
+    bool isConnected() const { return _state == GCS_ACTIVE || _state == GCS_ANNOUNCED; }
+
+    /**
+     * Get current state for debugging.
+     */
+    GrowattCloudState getState() const { return _state; }
+
+    /**
+     * Force reconnection.
+     */
+    void reconnect();
+
+    /**
+     * Update inverter serial (discovered via Modbus after boot).
+     */
+    void setInverterSerial(const char* serial);
+
+    /**
+     * Get stats for web UI / debugging.
+     */
+    uint32_t getPacketsSent() const { return _packetsSent; }
+    uint32_t getPacketsRecv() const { return _packetsRecv; }
+    uint32_t getReconnects() const { return _reconnects; }
+    uint32_t getLastSendTime() const { return _lastDataSend; }
+
+private:
+    // --- Connection management ---
+    void _connect();
+    void _disconnect();
+    bool _checkConnection();
+
+    // --- Protocol message builders ---
+    uint16_t _buildPing(uint8_t* buf);
+    uint16_t _buildAnnounce(uint8_t* buf, const uint16_t* holdingRegs, uint16_t numHoldingRegs);
+    uint16_t _buildData(uint8_t* buf, const uint16_t* inputRegs, uint16_t numInputRegs);
+
+    // --- Protocol message handlers ---
+    void _handleReceived();
+    void _handleAck(uint8_t funcCode);
+    void _handleIdentify(const uint8_t* data, uint16_t len);
+    void _handleConfigure(const uint8_t* data, uint16_t len);
+
+    // --- Header and encryption ---
+    void _writeHeader(uint8_t* buf, uint16_t transId, uint16_t protoId,
+                      uint16_t dataLen, uint8_t unitId, uint8_t funcCode);
+    void _xorEncrypt(uint8_t* data, uint16_t offset, uint16_t len);
+    void _xorDecrypt(uint8_t* data, uint16_t offset, uint16_t len);
+    uint16_t _calcCRC16(const uint8_t* data, uint16_t len);
+    void _writeSerial(uint8_t* buf, const char* serial);
+    void _writeTimestamp(uint8_t* buf);
+
+    // --- Send/receive helpers ---
+    bool _sendPacket(uint8_t* buf, uint16_t len);
+    int  _readPacket(uint8_t* buf, uint16_t maxLen);
+
+    // --- State ---
+    WiFiClient         _client;
+    GrowattCloudConfig _config;
+    GrowattCloudState  _state;
+    uint16_t           _transactionId;
+    uint32_t           _lastPing;
+    uint32_t           _lastDataSend;
+    uint32_t           _lastAnnounce;
+    uint32_t           _lastConnectAttempt;
+    uint8_t            _unackedCount;
+    bool               _announceAcked;
+
+    // --- Stats ---
+    uint32_t           _packetsSent;
+    uint32_t           _packetsRecv;
+    uint32_t           _reconnects;
+
+    // --- Buffers ---
+    uint8_t            _txBuf[GROWATT_MAX_PACKET];
+    uint8_t            _rxBuf[GROWATT_MAX_PACKET];
+};
+
+#endif // GROWATT_CLOUD_H

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -1,209 +1,352 @@
 #pragma once
 
-const char MAIN_page[] PROGMEM = R"=====(
+const char MAIN_page[] PROGMEM = R"rawliteral(
 <!DOCTYPE HTML>
-<html lang="en">
-
-<!-- Rui Santos - Complete project details at https://RandomNerdTutorials.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files.
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software. -->
-
+<html lang="en" data-theme="light">
 <head>
-    <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Growatt Inverter</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js" integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
-    <style>
-        body {
-            min-width: 310px;
-            max-width: 800px;
-            height: 400px;
-            margin: 0 auto;
-            font-family: Arial;
-        }
-
-        h2 {
-            font-size: 2.5rem;
-            text-align: center;
-        }
-
-        div {
-            font-size: 1rem;
-            padding: 10px 0px 10px 0px;
-        }
-
-        .linkButtonBar {
-            text-align: center;
-            padding: 20px 0px 20px 0px;
-        }
-
-        .linkButton {
-            -webkit-border-radius: 4px;
-            -moz-border-radius: 4px;
-            border-radius: 4px;
-            border: solid 1px #91ca5f;
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background: #6eb92b;
-            color: #FFF;
-            padding: 8px 12px;
-            text-decoration: none;
-            display: inline-block;
-            margin: 2px;
-            font-size: .8rem;
-            text-align: center;
-        }
-
-        .yellow {
-            border: solid 1px rgb(202, 189, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 178, 43);
-        }
-
-        .red {
-            border: solid 1px rgb(202, 95, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 43, 43);
-        }
-    </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Growatt Inverter</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+  onerror="document.body.classList.add('no-cdn')">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js"
+  integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw=="
+  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<style>
+  /* Tab bar */
+  .tabs{display:flex;gap:0;border-bottom:2px solid #ccc;margin-bottom:1rem}
+  .tabs button{background:none;border:none;padding:.6rem 1.2rem;cursor:pointer;
+    font-size:.95rem;border-bottom:3px solid transparent;color:#555}
+  .tabs button.active{border-bottom-color:#1a73e8;color:#1a73e8;font-weight:600}
+  .tabs button:hover{color:#1a73e8}
+  .tab-content{display:none}
+  .tab-content.active{display:block}
+  /* Status badges */
+  .badge{display:inline-block;padding:.15em .5em;border-radius:4px;font-size:.85rem;font-weight:600;color:#fff}
+  .badge-ok{background:#2e7d32}
+  .badge-warn{background:#ed6c02}
+  .badge-err{background:#d32f2f}
+  .badge-off{background:#757575}
+  /* Config form */
+  .cfg-msg{padding:.5rem;border-radius:4px;margin-bottom:.5rem;display:none}
+  .cfg-msg.ok{display:block;background:#e8f5e9;color:#2e7d32}
+  .cfg-msg.err{display:block;background:#ffebee;color:#c62828}
+  /* Debug iframe */
+  .debug-frame{width:100%;height:500px;border:1px solid #ccc;border-radius:4px}
+  /* Fallback CSS when CDN is offline */
+  .no-cdn{font-family:system-ui,-apple-system,sans-serif;max-width:900px;margin:0 auto;padding:1rem}
+  .no-cdn h1{font-size:1.6rem}
+  .no-cdn table{width:100%;border-collapse:collapse;margin:.5rem 0}
+  .no-cdn th,.no-cdn td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid #ddd}
+  .no-cdn input,.no-cdn select{padding:.3rem .5rem;border:1px solid #aaa;border-radius:3px;width:100%;box-sizing:border-box}
+  .no-cdn button[type=submit]{background:#1a73e8;color:#fff;border:none;padding:.5rem 1.5rem;border-radius:4px;cursor:pointer}
+  .no-cdn details{border:1px solid #ddd;border-radius:4px;padding:.5rem;margin:.5rem 0}
+  .no-cdn summary{cursor:pointer;font-weight:600}
+</style>
 </head>
-
 <body>
-    <h2>Growatt Inverter</h2>
+<main class="container">
+<h1>Growatt Inverter</h1>
 
-    <div><canvas id="powerChart"></canvas></div>
+<nav class="tabs">
+  <button class="active" data-tab="dash">Dashboard</button>
+  <button data-tab="cfg">Config</button>
+  <button data-tab="cloud">Cloud</button>
+  <button data-tab="dbg">Debug Log</button>
+  <button data-tab="sys">System</button>
+</nav>
 
-    <div class="linkButtonBar">
-        <a href="./status" class="linkButton">Json</a>
-        <a href="./uiStatus" class="linkButton">UI Json</a>
-        <a href="./metrics" class="linkButton">Metrics</a>
-        <a href="./debug" class="linkButton">Log</a>
-        <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp" class="linkButton yellow">Start Config AP</a>
-        <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot" class="linkButton yellow">Reboot</a>
-        <a href="./postCommunicationModbus" class="linkButton red">RW Modbus</a>
-    </div>
+<!-- ===== Dashboard Tab ===== -->
+<section id="tab-dash" class="tab-content active">
+  <div><canvas id="powerChart"></canvas></div>
+  <div id="DataContainer"></div>
+</section>
 
-    <div id="DataContainer"></div>
+<!-- ===== Config Tab ===== -->
+<section id="tab-cfg" class="tab-content">
+  <div id="cfgMsg" class="cfg-msg"></div>
+  <form id="cfgForm">
+    <details open>
+      <summary>Network</summary>
+      <label>Hostname <input name="hostname" id="c_hostname"></label>
+      <label>Static IP <input name="static_ip" id="c_static_ip" placeholder="leave blank for DHCP"></label>
+      <label>Netmask <input name="static_netmask" id="c_static_netmask"></label>
+      <label>Gateway <input name="static_gateway" id="c_static_gateway"></label>
+      <label>DNS <input name="static_dns" id="c_static_dns"></label>
+    </details>
+    <details>
+      <summary>MQTT</summary>
+      <label>Server <input name="mqtt_server" id="c_mqtt_server" placeholder="leave blank to disable"></label>
+      <label>Port <input name="mqtt_port" id="c_mqtt_port"></label>
+      <label>Topic <input name="mqtt_topic" id="c_mqtt_topic"></label>
+      <label>Username <input name="mqtt_user" id="c_mqtt_user"></label>
+      <label>Password <input name="mqtt_pwd" type="password" id="c_mqtt_pwd" placeholder="unchanged if blank"></label>
+      <small id="c_mqtt_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Growatt Cloud</summary>
+      <label>Datalogger Serial <input name="cloud_serial" id="c_cloud_serial" placeholder="from stick label"></label>
+      <label>Server <input name="cloud_server" id="c_cloud_server" placeholder="server.growatt.com"></label>
+    </details>
+    <details>
+      <summary>Authentication</summary>
+      <label>Username <input name="auth_user" id="c_auth_user" placeholder="blank = no auth"></label>
+      <label>Password <input name="auth_pass" type="password" id="c_auth_pass" placeholder="unchanged if blank"></label>
+      <small id="c_auth_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Advanced</summary>
+      <label>Syslog IP <input name="syslog_ip" id="c_syslog_ip" placeholder="leave blank for none"></label>
+    </details>
+    <label><input type="checkbox" name="restart" value="1"> Restart after saving</label>
+    <button type="submit">Save Configuration</button>
+  </form>
+</section>
+
+<!-- ===== Cloud Tab ===== -->
+<section id="tab-cloud" class="tab-content">
+  <table id="cloudTable" role="grid">
+    <tbody>
+      <tr><th>Status</th><td id="cl_state">--</td></tr>
+      <tr><th>Serial</th><td id="cl_serial">--</td></tr>
+      <tr><th>Server</th><td id="cl_server">--</td></tr>
+      <tr><th>Packets Sent</th><td id="cl_sent">--</td></tr>
+      <tr><th>Packets Received</th><td id="cl_recv">--</td></tr>
+      <tr><th>Reconnects</th><td id="cl_recon">--</td></tr>
+      <tr><th>Last Send</th><td id="cl_last">--</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ===== Debug Log Tab ===== -->
+<section id="tab-dbg" class="tab-content">
+  <p>WebSerial debug stream (port 8080):</p>
+  <iframe id="debugFrame" class="debug-frame"></iframe>
+</section>
+
+<!-- ===== System Tab ===== -->
+<section id="tab-sys" class="tab-content">
+  <table id="sysTable" role="grid">
+    <tbody>
+      <tr><th>Hostname</th><td id="s_host">--</td></tr>
+      <tr><th>IP Address</th><td id="s_ip">--</td></tr>
+      <tr><th>Gateway</th><td id="s_gw">--</td></tr>
+      <tr><th>Netmask</th><td id="s_mask">--</td></tr>
+      <tr><th>DNS</th><td id="s_dns">--</td></tr>
+      <tr><th>WiFi SSID</th><td id="s_ssid">--</td></tr>
+      <tr><th>WiFi RSSI</th><td id="s_rssi">--</td></tr>
+      <tr><th>MAC Address</th><td id="s_mac">--</td></tr>
+      <tr><th>Free Heap</th><td id="s_heap">--</td></tr>
+      <tr><th>Uptime</th><td id="s_up">--</td></tr>
+      <tr><th>Stick Type</th><td id="s_stick">--</td></tr>
+    </tbody>
+  </table>
+  <h4>Quick Links</h4>
+  <p>
+    <a href="./status" role="button" class="outline">JSON</a>
+    <a href="./uiStatus" role="button" class="outline">UI JSON</a>
+    <a href="./metrics" role="button" class="outline">Prometheus</a>
+    <a href="./postCommunicationModbus" role="button" class="outline secondary">RW Modbus</a>
+  </p>
+  <h4>Maintenance</h4>
+  <p>
+    <a href="./update" role="button" class="outline">Firmware Update</a>
+    <a href="#" role="button" class="outline contrast" id="btnAp"
+       onclick="if(confirm('Starting config AP will disconnect you. Continue?'))location='./startAp';return false;">Start Config AP</a>
+    <a href="#" role="button" class="outline contrast" id="btnReboot"
+       onclick="if(confirm('Reboot the WiFi stick?'))location='./reboot';return false;">Reboot</a>
+  </p>
+</section>
 
 <script>
-    let initialised = false;
-    const powerchartelement = document.getElementById('powerChart');
-
-    const CHART_COLORS = {
-        red: 'rgb(255, 99, 132)',
-        orange: 'rgb(255, 159, 64)',
-        yellow: 'rgb(255, 205, 86)',
-        green: 'rgb(75, 192, 192)',
-        blue: 'rgb(54, 162, 235)',
-        purple: 'rgb(153, 102, 255)',
-        grey: 'rgb(201, 203, 207)'
-    };
-
-    const NAMED_COLORS = [
-        CHART_COLORS.red,
-        CHART_COLORS.orange,
-        CHART_COLORS.yellow,
-        CHART_COLORS.green,
-        CHART_COLORS.blue,
-        CHART_COLORS.purple,
-        CHART_COLORS.grey,
-    ];
-
-    function namedColor(index) {
-        return NAMED_COLORS[index % NAMED_COLORS.length];
+/* ---- Tab switching ---- */
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    document.querySelectorAll('.tabs button').forEach(function(b){b.classList.remove('active')});
+    document.querySelectorAll('.tab-content').forEach(function(t){t.classList.remove('active')});
+    btn.classList.add('active');
+    var target = document.getElementById('tab-' + btn.getAttribute('data-tab'));
+    target.classList.add('active');
+    /* Lazy-load debug iframe */
+    if(btn.getAttribute('data-tab')==='dbg'){
+      var fr = document.getElementById('debugFrame');
+      if(!fr.src || fr.src===''){
+        fr.src = 'http://' + location.hostname + ':8080/';
+      }
     }
+    /* Fetch config when switching to config tab */
+    if(btn.getAttribute('data-tab')==='cfg') loadConfig();
+    /* Fetch system status */
+    if(btn.getAttribute('data-tab')==='sys') fetchSystem();
+  });
+});
 
-    const powerchartData = {
-        labels: [],
-        datasets: [],
-    };
-
-    let powerchart = new Chart(powerchartelement, {
-        type: 'line',
-        data: powerchartData,
-        options: {
-            scales: {
-                y: {
-                    beginAtZero: true
-                }
-            }
+/* ---- Dashboard: Chart.js + uiStatus polling (preserved from original) ---- */
+var initialised = false;
+var powerchartelement = document.getElementById('powerChart');
+var CHART_COLORS = {
+  red:'rgb(255,99,132)', orange:'rgb(255,159,64)', yellow:'rgb(255,205,86)',
+  green:'rgb(75,192,192)', blue:'rgb(54,162,235)', purple:'rgb(153,102,255)', grey:'rgb(201,203,207)'
+};
+var NAMED_COLORS = [CHART_COLORS.red, CHART_COLORS.orange, CHART_COLORS.yellow,
+  CHART_COLORS.green, CHART_COLORS.blue, CHART_COLORS.purple, CHART_COLORS.grey];
+function namedColor(i){return NAMED_COLORS[i % NAMED_COLORS.length]}
+var powerchartData = {labels:[], datasets:[]};
+var powerchart = new Chart(powerchartelement, {
+  type:'line', data:powerchartData,
+  options:{scales:{y:{beginAtZero:true}}}
+});
+setInterval(function(){
+  var xhttp = new XMLHttpRequest();
+  xhttp.onreadystatechange = function(){
+    if(this.readyState==4 && this.status==200){
+      var obj = JSON.parse(this.responseText);
+      var date = new Date();
+      powerchartData.labels.push(date.getHours()+":"+date.getMinutes()+":"+date.getSeconds());
+      if(initialised==false){
+        initialised = true;
+        var container = document.getElementById("DataContainer");
+        container.innerHTML = "";
+        for(var key in obj){
+          if(obj[key][2]==true){
+            var nd = {label:key, data:[obj[key][0]], fill:false,
+              borderColor:namedColor(powerchart.data.datasets.length), tension:0.1};
+            powerchartData.datasets.push(nd);
+            powerchart.update();
+          }
+          var el = document.createElement("p");
+          el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          el.setAttribute("id", key);
+          container.appendChild(el);
         }
-    });
-
-    setInterval(function () {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function () {
-            if (this.readyState == 4 && this.status == 200) {
-                // add data fields to the main page
-                var obj = JSON.parse(this.responseText);
-                // Add Date to chart x Axis
-                let date = new Date();
-                powerchartData.labels.push(date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds());
-                if (initialised == false) {
-                    initialised = true;
-                    // clear data view container just in case
-                    container = document.getElementById("DataContainer");
-                    container.innerHTML = "";
-                    // Add Data Labels to chart
-                    for (var key in obj) {
-                        if (obj[key][2] == true) {
-                            const newDataset = {
-                                label: key,
-                                data: [obj[key][0]],
-                                fill: false,
-                                borderColor: namedColor(powerchart.data.datasets.length),
-                                tension: 0.1
-                            };
-                            powerchartData.datasets.push(newDataset);
-                            powerchart.update();
-                        }
-                        // init dataview
-                        var element = document.createElement("p");
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        element.setAttribute("id", key);
-                        container.appendChild(element);
-                    }
-                } else {
-                    // Update Data in chart
-                    for (var key in obj) {
-                        // find dataset in array
-                        if (obj[key][2] == true) {
-                            for (var dset in powerchartData.datasets) {
-                                let leb = powerchartData.datasets[dset].label;
-                                if (leb == key) {
-                                    powerchartData.datasets[dset].data.push(obj[key][0]);
-                                }
-                            }
-                        }
-                        // update data view
-                        var element = document.getElementById(key);
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        powerchart.update();
-                    }
-                }
+      } else {
+        for(var key in obj){
+          if(obj[key][2]==true){
+            for(var d in powerchartData.datasets){
+              if(powerchartData.datasets[d].label==key){
+                powerchartData.datasets[d].data.push(obj[key][0]);
+              }
             }
+          }
+          var el = document.getElementById(key);
+          if(el) el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          powerchart.update();
         }
-        xhttp.open("GET", "./uiStatus", true);
-        xhttp.send();
-    }, 5000);
+      }
+    }
+  };
+  xhttp.open("GET","./uiStatus",true);
+  xhttp.send();
+}, 5000);
+
+/* ---- Config tab ---- */
+function loadConfig(){
+  fetch('./config').then(function(r){return r.json()}).then(function(d){
+    var fields = ['hostname','static_ip','static_netmask','static_gateway','static_dns',
+      'mqtt_server','mqtt_port','mqtt_topic','mqtt_user','cloud_serial','cloud_server',
+      'auth_user','syslog_ip'];
+    for(var i=0;i<fields.length;i++){
+      var el = document.getElementById('c_'+fields[i]);
+      if(el && d[fields[i]]!==undefined) el.value = d[fields[i]];
+    }
+    var mh = document.getElementById('c_mqtt_pwd_hint');
+    if(mh) mh.textContent = d.mqtt_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+    var ah = document.getElementById('c_auth_pwd_hint');
+    if(ah) ah.textContent = d.auth_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+  }).catch(function(e){
+    showCfgMsg('Failed to load config: '+e, true);
+  });
+}
+
+document.getElementById('cfgForm').addEventListener('submit', function(ev){
+  ev.preventDefault();
+  var msg = document.getElementById('cfgMsg');
+  msg.className = 'cfg-msg';
+  msg.textContent = 'Saving...';
+  msg.style.display = 'block';
+  fetch('./saveConfig', {
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+    body: new URLSearchParams(new FormData(this))
+  }).then(function(r){return r.json()}).then(function(d){
+    if(d.ok){
+      showCfgMsg(d.restart ? 'Saved! Restarting device...' : 'Configuration saved.', false);
+    } else {
+      showCfgMsg('Save failed.', true);
+    }
+  }).catch(function(e){
+    showCfgMsg('Error: '+e, true);
+  });
+});
+
+function showCfgMsg(text, isErr){
+  var el = document.getElementById('cfgMsg');
+  el.className = 'cfg-msg ' + (isErr ? 'err' : 'ok');
+  el.textContent = text;
+}
+
+/* ---- Cloud tab polling ---- */
+var cloudInterval = null;
+function fetchCloud(){
+  fetch('./cloudStatus').then(function(r){return r.json()}).then(function(d){
+    if(d.supported===false){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Not compiled</span>';
+      return;
+    }
+    if(!d.enabled){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Disabled</span>';
+      document.getElementById('cl_serial').textContent = 'Not configured';
+      return;
+    }
+    var sc = d.stateCode || 0;
+    var bc = sc >= 3 ? 'badge-ok' : (sc >= 1 ? 'badge-warn' : 'badge-err');
+    if(sc === 5) bc = 'badge-err';
+    document.getElementById('cl_state').innerHTML = '<span class="badge '+bc+'">'+d.state+'</span>';
+    document.getElementById('cl_serial').textContent = d.serial || '--';
+    document.getElementById('cl_server').textContent = d.server || '--';
+    document.getElementById('cl_sent').textContent = d.packetsSent;
+    document.getElementById('cl_recv').textContent = d.packetsRecv;
+    document.getElementById('cl_recon').textContent = d.reconnects;
+    document.getElementById('cl_last').textContent = d.lastSendAgo >= 0 ? d.lastSendAgo+'s ago' : 'never';
+  }).catch(function(){});
+}
+
+/* Start/stop cloud polling based on tab visibility */
+var origTabClick = null;
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    if(btn.getAttribute('data-tab')==='cloud'){
+      fetchCloud();
+      if(!cloudInterval) cloudInterval = setInterval(fetchCloud, 10000);
+    } else {
+      if(cloudInterval){clearInterval(cloudInterval); cloudInterval=null;}
+    }
+  });
+});
+
+/* ---- System tab ---- */
+function fetchSystem(){
+  fetch('./systemStatus').then(function(r){return r.json()}).then(function(d){
+    document.getElementById('s_host').textContent = d.hostname || '--';
+    document.getElementById('s_ip').textContent = d.ip || '--';
+    document.getElementById('s_gw').textContent = d.gateway || '--';
+    document.getElementById('s_mask').textContent = d.netmask || '--';
+    document.getElementById('s_dns').textContent = d.dns || '--';
+    document.getElementById('s_ssid').textContent = d.ssid || '--';
+    document.getElementById('s_mac').textContent = d.mac || '--';
+    document.getElementById('s_rssi').textContent = (d.rssi || 0) + ' dBm';
+    document.getElementById('s_heap').textContent = d.heap ? (d.heap + ' bytes') : '--';
+    var up = d.uptime || 0;
+    var h = Math.floor(up/3600); var m = Math.floor((up - h*3600)/60); var s = up - h*3600 - m*60;
+    document.getElementById('s_up').textContent = h+'h '+m+'m '+s+'s';
+    document.getElementById('s_stick').textContent = d.stickType || '--';
+  }).catch(function(){});
+}
 </script>
+</main>
 </body>
 </html>
-)=====";
+)rawliteral";
 
 const char SendPostSite_page[] PROGMEM = R"=====(
 <!DOCTYPE HTML><html>

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -11,6 +11,12 @@
 #include <WiFiManager.h>
 #include <StreamUtils.h>
 
+#ifdef ESP8266
+#include <Updater.h>
+#elif defined(ESP32)
+#include <Update.h>
+#endif
+
 #ifdef ESP32
 #include <esp_task_wdt.h>
 #endif
@@ -37,6 +43,10 @@ DoubleResetDetector* drd;
 #include "ShineMqtt.h"
 #endif
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+#include "GrowattCloud.h"
+#endif
+
 #if OTA_SUPPORTED == 1
 #include <ArduinoOTA.h>
 #endif
@@ -57,6 +67,11 @@ WiFiClientSecure espClient;
 WiFiClient espClient;
 #endif
 ShineMqtt shineMqtt(espClient, Inverter);
+#endif
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+GrowattCloud growattCloud;
+WiFiClient growattCloudClient;
 #endif
 
 #ifdef AP_BUTTON_PRESSED
@@ -92,7 +107,15 @@ struct {
   WiFiManagerParameter* mqtt_user = NULL;
   WiFiManagerParameter* mqtt_pwd = NULL;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  WiFiManagerParameter* cloud_serial = NULL;
+  WiFiManagerParameter* cloud_server = NULL;
+#endif
   WiFiManagerParameter* syslog_ip = NULL;
+#if ENABLE_WEB_AUTH == 1
+  WiFiManagerParameter* auth_user = NULL;
+  WiFiManagerParameter* auth_pass = NULL;
+#endif
 } customWMParams;
 
 static const struct {
@@ -108,7 +131,15 @@ static const struct {
   const char* mqtt_user = "/mqttu";
   const char* mqtt_pwd = "/mqttw";
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  const char* cloud_serial = "/cloudsn";
+  const char* cloud_server = "/cloudsrv";
+#endif
   const char* syslog_ip = "/syslogip";
+#if ENABLE_WEB_AUTH == 1
+  const char* auth_user = "/authuser";
+  const char* auth_pass = "/authpass";
+#endif
   const char* force_ap = "/forceap";
 } ConfigFiles;
 
@@ -121,7 +152,15 @@ struct {
 #if MQTT_SUPPORTED == 1
   MqttConfig mqtt;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  String cloud_serial;
+  String cloud_server;
+#endif
   String syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  String auth_user;
+  String auth_pass;
+#endif
   bool force_ap;
 } Config;
 
@@ -210,7 +249,15 @@ void loadConfig() {
   Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user, "");
   Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd, "");
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = prefs.getString(ConfigFiles.cloud_serial, "");
+  Config.cloud_server = prefs.getString(ConfigFiles.cloud_server, "server.growatt.com");
+#endif
   Config.syslog_ip = prefs.getString(ConfigFiles.syslog_ip, "");
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = prefs.getString(ConfigFiles.auth_user, "");
+  Config.auth_pass = prefs.getString(ConfigFiles.auth_pass, "");
+#endif
   Config.force_ap = prefs.getBool(ConfigFiles.force_ap, false);
 }
 
@@ -227,7 +274,15 @@ void saveConfig() {
   prefs.putString(ConfigFiles.mqtt_user, Config.mqtt.user);
   prefs.putString(ConfigFiles.mqtt_pwd, Config.mqtt.pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  prefs.putString(ConfigFiles.cloud_serial, Config.cloud_serial);
+  prefs.putString(ConfigFiles.cloud_server, Config.cloud_server);
+#endif
   prefs.putString(ConfigFiles.syslog_ip, Config.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  prefs.putString(ConfigFiles.auth_user, Config.auth_user);
+  prefs.putString(ConfigFiles.auth_pass, Config.auth_pass);
+#endif
 }
 
 void saveParamCallback() {
@@ -248,7 +303,21 @@ void saveParamCallback() {
   Config.mqtt.user = customWMParams.mqtt_user->getValue();
   Config.mqtt.pwd = customWMParams.mqtt_pwd->getValue();
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = customWMParams.cloud_serial->getValue();
+  Config.cloud_server = customWMParams.cloud_server->getValue();
+  if (Config.cloud_server.isEmpty()) {
+    Config.cloud_server = "server.growatt.com";
+  }
+#endif
   Config.syslog_ip = customWMParams.syslog_ip->getValue();
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = customWMParams.auth_user->getValue();
+  {
+    String val = customWMParams.auth_pass->getValue();
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
 
   saveConfig();
 
@@ -471,11 +540,63 @@ void setup() {
 #ifdef ENABLE_WEB_DEBUG
   httpServer.on("/debug", sendDebug);
 #endif
+  httpServer.on("/config", HTTP_GET, sendConfigJson);
+  httpServer.on("/saveConfig", HTTP_POST, handleSaveConfig);
+  httpServer.on("/cloudStatus", sendCloudStatus);
+  httpServer.on("/systemStatus", sendSystemStatus);
+  httpServer.on("/update", HTTP_GET, sendUpdatePage);
+  httpServer.on("/doUpdate", HTTP_POST, handleUpdateDone, handleUpdateUpload);
   httpServer.onNotFound(handleNotFound);
 
   Inverter.InitProtocol();
   InverterReconnect();
   httpServer.begin();
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Try to auto-read serial from stock firmware's flash area (0x3FD0B4)
+  // This survives OIG flashing since we only write the first ~500KB
+  if (Config.cloud_serial.isEmpty()) {
+    uint8_t flashBuf[12] = {0};
+    char flashSerial[11] = {0};
+    bool found = false;
+#ifdef ESP8266
+    if (ESP.flashRead(0x3FD0B4, (uint32_t*)flashBuf, 12)) {
+      memcpy(flashSerial, flashBuf, 10);
+      flashSerial[10] = '\0';
+      found = true;
+      for (int i = 0; i < 10 && found; i++) {
+        if (flashSerial[i] < 0x20 || flashSerial[i] > 0x7E) {
+          if (i == 0) found = false;
+          else flashSerial[i] = '\0';
+        }
+      }
+    }
+#endif
+    if (found && strlen(flashSerial) >= 6) {
+      Config.cloud_serial = String(flashSerial);
+      saveConfig();
+      Log.print(F("[GrowattCloud] Auto-detected serial from flash: "));
+      Log.println(Config.cloud_serial);
+    }
+  }
+
+  if (!Config.cloud_serial.isEmpty()) {
+    GrowattCloudConfig cloudCfg;
+    strncpy(cloudCfg.serverHost, Config.cloud_server.c_str(), sizeof(cloudCfg.serverHost) - 1);
+    cloudCfg.serverPort = GROWATT_PORT_DEFAULT;
+    cloudCfg.protocolId = GROWATT_PROTO_ENC_V2;
+    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), GROWATT_SERIAL_LEN);
+    memset(cloudCfg.inverterSerial, 0, sizeof(cloudCfg.inverterSerial));
+    strncpy(cloudCfg.fwVersion, "1.7.7.7", sizeof(cloudCfg.fwVersion) - 1);
+    cloudCfg.logIntervalMin = 5;
+    cloudCfg.enabled = true;
+    growattCloud.begin(cloudCfg);
+    Log.println(F("[GrowattCloud] Enabled, serial: "));
+    Log.println(Config.cloud_serial);
+  } else {
+    Log.println(F("[GrowattCloud] Disabled (no serial configured)"));
+  }
+#endif
 
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
 #ifdef ESP32
@@ -524,6 +645,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.mqtt_user);
   wm.addParameter(customWMParams.mqtt_pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  customWMParams.cloud_serial = new WiFiManagerParameter(
+      "cloudsn", "Datalogger Serial (from stick label/AP SSID)",
+      Config.cloud_serial.c_str(), 30);
+  customWMParams.cloud_server = new WiFiManagerParameter(
+      "cloudsrv", "Cloud Server (default: server.growatt.com)",
+      Config.cloud_server.c_str(), 60);
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Growatt Cloud</b> (enter serial to enable, leave blank to disable)</p>"));
+  wm.addParameter(customWMParams.cloud_serial);
+  wm.addParameter(customWMParams.cloud_server);
+#endif
   wm.addParameter(new WiFiManagerParameter(
       "<p><b>Static IP</b> (leave blank for DHCP)</p>"));
   wm.addParameter(customWMParams.static_ip);
@@ -532,6 +665,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.static_dns);
   wm.addParameter(new WiFiManagerParameter("<p><b>Advanced Settings</b></p>"));
   wm.addParameter(customWMParams.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  customWMParams.auth_user = new WiFiManagerParameter(
+      "authuser", "Web UI Username (blank=no auth)",
+      Config.auth_user.c_str(), 30);
+  customWMParams.auth_pass = new WiFiManagerParameter(
+      "authpass", "Web UI Password",
+      "", 30);  // Don't show current password
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Web Authentication</b> (leave blank for open access)</p>"));
+  wm.addParameter(customWMParams.auth_user);
+  wm.addParameter(customWMParams.auth_pass);
+#endif
 
   wm.setSaveParamsCallback(saveParamCallback);
 
@@ -556,6 +701,19 @@ void setupMenu(WiFiManager& wm, bool enableCustomParams) {
   wm.setMenu(menu);  // custom menu, pass vector
 }
 
+bool checkAuth() {
+#if ENABLE_WEB_AUTH == 1
+  if (Config.auth_user.isEmpty() || Config.auth_pass.isEmpty()) {
+    return true;
+  }
+  if (!httpServer.authenticate(Config.auth_user.c_str(), Config.auth_pass.c_str())) {
+    httpServer.requestAuthentication(BASIC_AUTH, "Growatt Inverter");
+    return false;
+  }
+#endif
+  return true;
+}
+
 void sendJson(JsonDocument& doc) {
   httpServer.setContentLength(measureJson(doc));
   httpServer.send(200, "application/json", "");
@@ -565,6 +723,7 @@ void sendJson(JsonDocument& doc) {
 }
 
 void sendJsonSite(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -577,6 +736,7 @@ void sendJsonSite(void) {
 }
 
 void sendUiJsonSite(void) {
+  if (!checkAuth()) return;
   DynamicJsonDocument doc(JSON_DOCUMENT_SIZE);
   Inverter.CreateUIJson(doc, Config.hostname);
 
@@ -584,6 +744,7 @@ void sendUiJsonSite(void) {
 }
 
 void sendMetrics(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -616,6 +777,7 @@ boolean sendMqttJson(void) {
 #endif
 
 void startConfigAccessPoint(void) {
+  if (!checkAuth()) return;
   char msg[384];
 
   snprintf_P(msg, sizeof(msg),
@@ -632,6 +794,7 @@ void startConfigAccessPoint(void) {
 }
 
 void rebootESP(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, F("text/html"),
                   F("<html><body>Rebooting...</body></html>"));
   delay(2000);
@@ -640,19 +803,25 @@ void rebootESP(void) {
 
 #ifdef ENABLE_WEB_DEBUG
 void sendDebug(void) {
+  if (!checkAuth()) return;
   httpServer.sendHeader("Location",
                         "http://" + WiFi.localIP().toString() + ":8080/", true);
   httpServer.send(302, "text/plain", "");
 }
 #endif
 
-void sendMainPage(void) { httpServer.send(200, "text/html", MAIN_page); }
+void sendMainPage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, "text/html", MAIN_page);
+}
 
 void sendPostSite(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, "text/html", SendPostSite_page);
 }
 
 void handlePostData() {
+  if (!checkAuth()) return;
   char msg[256];
   uint16_t u16Tmp;
   uint32_t u32Tmp;
@@ -747,6 +916,176 @@ void handlePostData() {
   }
 }
 
+// -------------------------------------------------------
+// OTA Firmware Update via Web UI
+// -------------------------------------------------------
+void sendUpdatePage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, F("text/html"),
+    F("<!DOCTYPE html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>"
+      "<title>Firmware Update</title>"
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css'>"
+      "</head><body><main class='container'>"
+      "<h2>Firmware Update</h2>"
+      "<form method='POST' action='/doUpdate' enctype='multipart/form-data'>"
+      "<label>Select firmware .bin file:<input type='file' name='update' accept='.bin' required></label>"
+      "<button type='submit'>Upload and Flash</button>"
+      "</form>"
+      "<p><a href='/'>Back to Dashboard</a></p>"
+      "</main></body></html>"));
+}
+
+void handleUpdateUpload(void) {
+  if (!checkAuth()) return;
+  HTTPUpload& upload = httpServer.upload();
+  if (upload.status == UPLOAD_FILE_START) {
+    Log.printf("OTA Update: %s (%u bytes)\n", upload.filename.c_str(), upload.totalSize);
+    uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
+    if (!Update.begin(maxSketchSpace)) {
+      Log.println(F("OTA: Not enough space"));
+    }
+  } else if (upload.status == UPLOAD_FILE_WRITE) {
+    if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
+      Log.println(F("OTA: Write failed"));
+    }
+  } else if (upload.status == UPLOAD_FILE_END) {
+    if (Update.end(true)) {
+      Log.printf("OTA: Success, %u bytes\n", upload.totalSize);
+    } else {
+      Log.println(F("OTA: Failed"));
+    }
+  }
+  yield();
+}
+
+void handleUpdateDone(void) {
+  if (!checkAuth()) return;
+  bool ok = !Update.hasError();
+  httpServer.send(200, F("text/html"),
+    ok ? F("<!DOCTYPE html><html><body><h2>Update Successful!</h2><p>Rebooting...</p></body></html>")
+       : F("<!DOCTYPE html><html><body><h2>Update Failed!</h2><p><a href='/update'>Try again</a></p></body></html>"));
+  if (ok) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendConfigJson(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<512> doc;
+  doc["hostname"] = Config.hostname;
+  doc["static_ip"] = Config.static_ip;
+  doc["static_netmask"] = Config.static_netmask;
+  doc["static_gateway"] = Config.static_gateway;
+  doc["static_dns"] = Config.static_dns;
+#if MQTT_SUPPORTED == 1
+  doc["mqtt_server"] = Config.mqtt.server;
+  doc["mqtt_port"] = Config.mqtt.port;
+  doc["mqtt_topic"] = Config.mqtt.topic;
+  doc["mqtt_user"] = Config.mqtt.user;
+  doc["mqtt_pwd_set"] = !Config.mqtt.pwd.isEmpty();
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloud_serial"] = Config.cloud_serial;
+  doc["cloud_server"] = Config.cloud_server;
+#endif
+  doc["syslog_ip"] = Config.syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  doc["auth_user"] = Config.auth_user;
+  doc["auth_pwd_set"] = !Config.auth_pass.isEmpty();
+#endif
+  sendJson(doc);
+}
+
+void handleSaveConfig(void) {
+  if (!checkAuth()) return;
+  if (httpServer.hasArg(F("hostname"))) Config.hostname = httpServer.arg(F("hostname"));
+  if (httpServer.hasArg(F("static_ip"))) Config.static_ip = httpServer.arg(F("static_ip"));
+  if (httpServer.hasArg(F("static_netmask"))) Config.static_netmask = httpServer.arg(F("static_netmask"));
+  if (httpServer.hasArg(F("static_gateway"))) Config.static_gateway = httpServer.arg(F("static_gateway"));
+  if (httpServer.hasArg(F("static_dns"))) Config.static_dns = httpServer.arg(F("static_dns"));
+#if MQTT_SUPPORTED == 1
+  if (httpServer.hasArg(F("mqtt_server"))) Config.mqtt.server = httpServer.arg(F("mqtt_server"));
+  if (httpServer.hasArg(F("mqtt_port"))) Config.mqtt.port = httpServer.arg(F("mqtt_port"));
+  if (httpServer.hasArg(F("mqtt_topic"))) Config.mqtt.topic = httpServer.arg(F("mqtt_topic"));
+  if (httpServer.hasArg(F("mqtt_user"))) Config.mqtt.user = httpServer.arg(F("mqtt_user"));
+  if (httpServer.hasArg(F("mqtt_pwd"))) {
+    String val = httpServer.arg(F("mqtt_pwd"));
+    if (!val.isEmpty()) Config.mqtt.pwd = val;
+  }
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (httpServer.hasArg(F("cloud_serial"))) Config.cloud_serial = httpServer.arg(F("cloud_serial"));
+  if (httpServer.hasArg(F("cloud_server"))) {
+    String val = httpServer.arg(F("cloud_server"));
+    Config.cloud_server = val.isEmpty() ? "server.growatt.com" : val;
+  }
+#endif
+  if (httpServer.hasArg(F("syslog_ip"))) Config.syslog_ip = httpServer.arg(F("syslog_ip"));
+#if ENABLE_WEB_AUTH == 1
+  if (httpServer.hasArg(F("auth_user"))) Config.auth_user = httpServer.arg(F("auth_user"));
+  if (httpServer.hasArg(F("auth_pass"))) {
+    String val = httpServer.arg(F("auth_pass"));
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
+  saveConfig();
+  bool needRestart = httpServer.hasArg(F("restart"));
+  httpServer.send(200, F("application/json"),
+    needRestart ? F("{\"ok\":true,\"restart\":true}") : F("{\"ok\":true}"));
+  if (needRestart) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendCloudStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<256> doc;
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (!Config.cloud_serial.isEmpty()) {
+    doc["enabled"] = true;
+    const char* stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
+    doc["state"] = stateNames[growattCloud.getState()];
+    doc["stateCode"] = (int)growattCloud.getState();
+    doc["packetsSent"] = growattCloud.getPacketsSent();
+    doc["packetsRecv"] = growattCloud.getPacketsRecv();
+    doc["reconnects"] = growattCloud.getReconnects();
+    uint32_t lastSend = growattCloud.getLastSendTime();
+    doc["lastSendAgo"] = lastSend > 0 ? (int)((millis() - lastSend) / 1000) : -1;
+    doc["serial"] = Config.cloud_serial;
+    doc["server"] = Config.cloud_server;
+  } else {
+    doc["enabled"] = false;
+  }
+#else
+  doc["supported"] = false;
+#endif
+  sendJson(doc);
+}
+
+void sendSystemStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<384> doc;
+  doc["hostname"] = Config.hostname;
+  doc["ip"] = WiFi.localIP().toString();
+  doc["gateway"] = WiFi.gatewayIP().toString();
+  doc["netmask"] = WiFi.subnetMask().toString();
+  doc["dns"] = WiFi.dnsIP().toString();
+  doc["ssid"] = WiFi.SSID();
+  doc["rssi"] = WiFi.RSSI();
+  doc["heap"] = ESP.getFreeHeap();
+  doc["uptime"] = millis() / 1000;
+  doc["mac"] = WiFi.macAddress();
+  doc["stickType"] = Inverter.GetWiFiStickType() == ShineWiFi_S ? "ShineWiFi-S" :
+                     Inverter.GetWiFiStickType() == ShineWiFi_X ? "ShineWiFi-X" : "Unknown";
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloudSerial"] = Config.cloud_serial;
+  doc["cloudState"] = growattCloud.isConnected() ? "Active" : "Disconnected";
+#endif
+  sendJson(doc);
+}
+
 bool sendSingleValue(void) {
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
@@ -762,6 +1101,7 @@ bool sendSingleValue(void) {
 }
 
 void handleNotFound() {
+  if (!checkAuth()) return;
   if (httpServer.uri().startsWith(F("/value/")) &&
       httpServer.uri().length() > 7) {
     if (sendSingleValue()) {
@@ -896,6 +1236,24 @@ void loop() {
 #endif
           handleWdtReset(mqttSuccess);
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+          // Feed register data to Growatt Cloud sender
+          if (!Config.cloud_serial.isEmpty()) {
+            // Build arrays of raw register values for cloud protocol
+            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
+            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            uint16_t inputRegs[125];
+            uint16_t holdingRegs[35];
+            for (uint16_t i = 0; i < numInput && i < 125; i++) {
+              inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
+            }
+            for (uint16_t i = 0; i < numHolding && i < 35; i++) {
+              holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
+            }
+            growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);
+          }
+#endif
+
           // leave while-loop
           readoutSucceeded = true;
         } else {
@@ -943,6 +1301,13 @@ void loop() {
 
     RefreshTimer = now;
   }
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Keep Growatt Cloud connection alive (pings, server responses)
+  if (!Config.cloud_serial.isEmpty()) {
+    growattCloud.loop(nullptr, 0);
+  }
+#endif
 
 #if OTA_SUPPORTED == 1
   // check for OTA updates


### PR DESCRIPTION
## Summary

Adds Growatt Cloud protocol support enabling **dual-mode operation**: local MQTT/Prometheus monitoring AND Growatt ShinePhone app/cloud portal access simultaneously from the same ShineWiFi-S/X stick.

The Growatt proprietary TCP protocol (server.growatt.com:5279) was reverse-engineered from a stock firmware flash dump and verified end-to-end -- inverter power values confirmed appearing on the Growatt web portal.

### Features

**Growatt Cloud Protocol (GrowattCloud.cpp/h)**
- Implements Growatt TCP protocol with XOR obfuscation and Modbus CRC-16
- PING keepalive, ANNOUNCE, DATA (FC04 input registers 0-89 in T06NNNN layout)
- Handles server IDENTIFY queries and CONFIG pushes
- Auto-detects datalogger serial number from stock firmware's flash area (survives reflash)
- Configurable server address and serial via web UI

**Web UI Overhaul (Index.h)**
- Modern tabbed interface using Pico CSS (CDN with graceful fallback)
- 5 tabs: Dashboard (live charts), Config, Cloud Status, Debug Log, System
- Configuration changes in normal operation mode (no AP mode restart needed)
- Optional HTTP Basic Auth for web UI protection
- Embedded debug log viewer via iframe
- HTTP firmware update endpoint (`/update`) for OTA without serial adapter
- System info: hostname, IP, gateway, netmask, DNS, SSID, WiFi signal, heap

**Improved Modbus Detection (Growatt.cpp)**
- Scans Modbus addresses 1-5 instead of hardcoding address 1
- 2-second startup delay for RS232 transceiver stabilization
- Tries both FC04 (input registers) and FC03 (holding registers) at each address
- Logs the detected address and baud rate

### Protocol Details

The Growatt Cloud protocol was verified by:
1. Capturing stock firmware packets via Grott proxy
2. Decoding the exact byte layout (proto 0x0006, 265-byte packets)
3. Modifying a captured packet (changing output power value)
4. Sending it from a Python script and confirming the value appeared on server.growatt.com

### Configuration

New `Config.h` options:
- `GROWATT_CLOUD_SUPPORTED` - Enable/disable cloud forwarding (default: enabled)
- `ENABLE_WEB_AUTH` - Enable/disable HTTP Basic Auth (default: enabled)

The datalogger serial is auto-detected from the stock firmware's flash storage at offset `0x3FD0B4`. No manual configuration needed if stock firmware was previously installed.

## Test plan

- [x] Builds successfully for ShineWifiS, ShineWifiX environments
- [x] Modbus detection works with address scanning (tested on Growatt 4000TL3-S)
- [x] MQTT publishing to Home Assistant confirmed
- [x] Growatt Cloud: PING/ANNOUNCE/DATA accepted by server.growatt.com
- [x] Growatt Cloud: pac value confirmed on web portal (1234.0W test value)
- [x] Web UI: tabs, config, cloud status, debug log all functional
- [x] Serial auto-detect reads correct serial from flash
- [ ] Test with ShineWiFi-X (USB variant)
- [ ] Test with different inverter models (SPH, MIN, TL-X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)