### PR TITLE
fix: Scan Modbus addresses 1-5 with startup delay for reliable inverter detection

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -92,19 +92,49 @@ void Growatt::begin(Stream& serial) {
 #else
   uint8_t res;
   // init communication with the inverter
+  // Stock firmware scans Modbus addresses, not just address 1
+  // Also needs startup delay for RS232 transceiver to stabilize
+
+  // Try ShineWiFi-S (Serial, 9600 baud) - scan addresses 1-5
   Serial.begin(9600);
-  Modbus.begin(1, serial);
-  res = Modbus.readInputRegisters(0, 1);
-  if (res == Modbus.ku8MBSuccess) {
-    _eDevice = ShineWiFi_S;  // Serial
-  } else {
-    delay(1000);
-    Serial.begin(115200);
-    Modbus.begin(1, serial);
-    Modbus.setResponseTimeout(250);
+  delay(2000);  // Wait for RS232 transceiver + inverter boot
+  for (uint8_t addr = 1; addr <= 5 && _eDevice == Undef_stick; addr++) {
+    Modbus.begin(addr, serial);
+    // Try FC04 (input registers) first
     res = Modbus.readInputRegisters(0, 1);
     if (res == Modbus.ku8MBSuccess) {
-      _eDevice = ShineWiFi_X;  // USB
+      _eDevice = ShineWiFi_S;
+      Log.printf("ShineWiFi-S found at Modbus address %d (9600 baud, FC04)\n",
+                 addr);
+      break;
+    }
+    // Try FC03 (holding registers) as fallback
+    res = Modbus.readHoldingRegisters(0, 1);
+    if (res == Modbus.ku8MBSuccess) {
+      _eDevice = ShineWiFi_S;
+      Log.printf("ShineWiFi-S found at Modbus address %d (9600 baud, FC03)\n",
+                 addr);
+      break;
+    }
+    delay(200);
+  }
+
+  // Try ShineWiFi-X (USB, 115200 baud) - scan addresses 1-5
+  if (_eDevice == Undef_stick) {
+    delay(1000);
+    Serial.begin(115200);
+    delay(500);
+    for (uint8_t addr = 1; addr <= 5 && _eDevice == Undef_stick; addr++) {
+      Modbus.begin(addr, serial);
+      Modbus.setResponseTimeout(250);
+      res = Modbus.readInputRegisters(0, 1);
+      if (res == Modbus.ku8MBSuccess) {
+        _eDevice = ShineWiFi_X;
+        Log.printf("ShineWiFi-X found at Modbus address %d (115200 baud)\n",
+                   addr);
+        break;
+      }
+      delay(200);
     }
     delay(1000);
   }


### PR DESCRIPTION
## Summary

- Scan Modbus addresses 1-5 instead of hardcoding address 1
- Add 2-second startup delay for RS232 transceiver stabilization
- Try both FC04 and FC03 at each address as fallback
- Log detected address and baud rate

## Why

The stock Growatt firmware scans multiple addresses. Some inverters use non-default Modbus addresses, causing "Unknown Shine Stick" errors. The startup delay is needed because the SP3232 RS232 transceiver needs time to stabilize after ESP8266 boot.

## Test plan
- [x] Tested on Growatt 4000TL3-S (Protocol v3.05, addr 1, 9600 baud)
- [ ] Test with inverters using non-default addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)