### PR TITLE
feat: Web UI overhaul - tabbed interface, config in normal mode, HTTP auth

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -22,6 +22,18 @@
 // Setting this define to 0 will disable the MQTT functionality
 #define MQTT_SUPPORTED 1
 
+// Setting this define to 1 enables Growatt Cloud forwarding.
+// Sends inverter data to server.growatt.com:5279 so ShinePhone app
+// and Growatt web portal continue working alongside local MQTT.
+// The datalogger serial is auto-detected from the stock firmware's
+// flash area, or can be entered in the GrowattConfig portal.
+#define GROWATT_CLOUD_SUPPORTED 1
+
+// Setting this define to 1 enables HTTP Basic Auth for the web UI.
+// Auth credentials are configured via the GrowattConfig portal or web UI.
+// If no credentials are set, the UI is open (backward compatible).
+#define ENABLE_WEB_AUTH 1
+
 // Enable OTA update via espota. This is mainly for development purposes and enables updates
 // of the device without physical access. Use at our own risk!
 #define OTA_SUPPORTED 0

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -27,7 +27,11 @@
 // and Growatt web portal continue working alongside local MQTT.
 // The datalogger serial is auto-detected from the stock firmware's
 // flash area, or can be entered in the GrowattConfig portal.
-#define GROWATT_CLOUD_SUPPORTED 1
+//
+// NOTE: enabling this requires GrowattCloud.{h,cpp} to be present.
+// Those files are introduced in a separate PR; until that PR is merged,
+// keep this flag at 0 to build the rest of the changes standalone.
+#define GROWATT_CLOUD_SUPPORTED 0
 
 // Setting this define to 1 enables HTTP Basic Auth for the web UI.
 // Auth credentials are configured via the GrowattConfig portal or web UI.

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -39,27 +39,29 @@ void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter) {
       32,          0,    SIZE_16BIT, F("Temperature"), 0.1, 0.1,
       TEMPERATURE, true, false};  // #12
 
-  // Additional registers needed by the Growatt cloud DATA frame (T06NNNN format).
+  // Additional registers needed by the Growatt cloud DATA frame (T06NNNN format)
+  // and to surface 3-phase data on the dashboard.
   // The cloud reads "pac" from registers 11-12 and per-phase data from 18-25;
-  // without these entries the cloud sees zeros for total AC power on TL3 inverters.
+  // without these entries the cloud sees zeros for total AC power on TL3 inverters
+  // and the dashboard /uiStatus omits the L2/L3 columns entirely.
   Protocol.InputRegisters[P305_PAC_TOTAL] = sGrowattModbusReg_t{
-      11, 0, SIZE_32BIT, F("PacTotal"), 0.1, 0.1, POWER_W, false, false};
+      11, 0, SIZE_32BIT, F("PacTotal"), 0.1, 0.1, POWER_W, true, true};
   Protocol.InputRegisters[P305_PV_POWER_IN] = sGrowattModbusReg_t{
-      1, 0, SIZE_32BIT, F("PpvTotal"), 0.1, 0.1, POWER_W, false, false};
+      1, 0, SIZE_32BIT, F("PpvTotal"), 0.1, 0.1, POWER_W, true, false};
   Protocol.InputRegisters[P305_PV1_WATT] = sGrowattModbusReg_t{
-      5, 0, SIZE_32BIT, F("Pv1Watt"), 0.1, 0.1, POWER_W, false, false};
+      5, 0, SIZE_32BIT, F("Pv1Watt"), 0.1, 0.1, POWER_W, true, false};
   Protocol.InputRegisters[P305_VAC_L2] = sGrowattModbusReg_t{
-      18, 0, SIZE_16BIT, F("AcVoltageL2"), 0.1, 0.1, VOLTAGE, false, false};
+      18, 0, SIZE_16BIT, F("AcVoltageL2"), 0.1, 0.1, VOLTAGE, true, false};
   Protocol.InputRegisters[P305_IAC_L2] = sGrowattModbusReg_t{
-      19, 0, SIZE_16BIT, F("AcCurrentL2"), 0.1, 0.1, CURRENT, false, false};
+      19, 0, SIZE_16BIT, F("AcCurrentL2"), 0.1, 0.1, CURRENT, true, false};
   Protocol.InputRegisters[P305_PAC_L2] = sGrowattModbusReg_t{
-      20, 0, SIZE_32BIT, F("AcPowerL2"), 0.1, 0.1, POWER_W, false, false};
+      20, 0, SIZE_32BIT, F("AcPowerL2"), 0.1, 0.1, POWER_W, true, false};
   Protocol.InputRegisters[P305_VAC_L3] = sGrowattModbusReg_t{
-      22, 0, SIZE_16BIT, F("AcVoltageL3"), 0.1, 0.1, VOLTAGE, false, false};
+      22, 0, SIZE_16BIT, F("AcVoltageL3"), 0.1, 0.1, VOLTAGE, true, false};
   Protocol.InputRegisters[P305_IAC_L3] = sGrowattModbusReg_t{
-      23, 0, SIZE_16BIT, F("AcCurrentL3"), 0.1, 0.1, CURRENT, false, false};
+      23, 0, SIZE_16BIT, F("AcCurrentL3"), 0.1, 0.1, CURRENT, true, false};
   Protocol.InputRegisters[P305_PAC_L3] = sGrowattModbusReg_t{
-      24, 0, SIZE_32BIT, F("AcPowerL3"), 0.1, 0.1, POWER_W, false, false};
+      24, 0, SIZE_32BIT, F("AcPowerL3"), 0.1, 0.1, POWER_W, true, false};
 
   Protocol.InputRegisterCount = 21;
   Protocol.InputFragmentCount = 1;

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -4,8 +4,7 @@
 #include "Growatt305.h"
 
 void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter) {
-  // definition of input registers
-  Protocol.InputRegisterCount = 12;
+  // definition of input registers — set below after all entries are added
   // address, value, size, name, multiplier, unit, frontend, plot
   // FRAGMENT 1: BEGIN
   Protocol.InputRegisters[P305_I_STATUS] = sGrowattModbusReg_t{
@@ -40,6 +39,29 @@ void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter) {
       32,          0,    SIZE_16BIT, F("Temperature"), 0.1, 0.1,
       TEMPERATURE, true, false};  // #12
 
+  // Additional registers needed by the Growatt cloud DATA frame (T06NNNN format).
+  // The cloud reads "pac" from registers 11-12 and per-phase data from 18-25;
+  // without these entries the cloud sees zeros for total AC power on TL3 inverters.
+  Protocol.InputRegisters[P305_PAC_TOTAL] = sGrowattModbusReg_t{
+      11, 0, SIZE_32BIT, F("PacTotal"), 0.1, 0.1, POWER_W, false, false};
+  Protocol.InputRegisters[P305_PV_POWER_IN] = sGrowattModbusReg_t{
+      1, 0, SIZE_32BIT, F("PpvTotal"), 0.1, 0.1, POWER_W, false, false};
+  Protocol.InputRegisters[P305_PV1_WATT] = sGrowattModbusReg_t{
+      5, 0, SIZE_32BIT, F("Pv1Watt"), 0.1, 0.1, POWER_W, false, false};
+  Protocol.InputRegisters[P305_VAC_L2] = sGrowattModbusReg_t{
+      18, 0, SIZE_16BIT, F("AcVoltageL2"), 0.1, 0.1, VOLTAGE, false, false};
+  Protocol.InputRegisters[P305_IAC_L2] = sGrowattModbusReg_t{
+      19, 0, SIZE_16BIT, F("AcCurrentL2"), 0.1, 0.1, CURRENT, false, false};
+  Protocol.InputRegisters[P305_PAC_L2] = sGrowattModbusReg_t{
+      20, 0, SIZE_32BIT, F("AcPowerL2"), 0.1, 0.1, POWER_W, false, false};
+  Protocol.InputRegisters[P305_VAC_L3] = sGrowattModbusReg_t{
+      22, 0, SIZE_16BIT, F("AcVoltageL3"), 0.1, 0.1, VOLTAGE, false, false};
+  Protocol.InputRegisters[P305_IAC_L3] = sGrowattModbusReg_t{
+      23, 0, SIZE_16BIT, F("AcCurrentL3"), 0.1, 0.1, CURRENT, false, false};
+  Protocol.InputRegisters[P305_PAC_L3] = sGrowattModbusReg_t{
+      24, 0, SIZE_32BIT, F("AcPowerL3"), 0.1, 0.1, POWER_W, false, false};
+
+  Protocol.InputRegisterCount = 21;
   Protocol.InputFragmentCount = 1;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 33};
 

--- a/SRC/ShineWiFi-ModBus/Growatt305.h
+++ b/SRC/ShineWiFi-ModBus/Growatt305.h
@@ -18,6 +18,15 @@ typedef enum {
   P305_ENERGY_TOTAL,
   P305_OPERATING_TIME,
   P305_TEMPERATURE,
+  P305_PAC_TOTAL,    // reg 11-12, total AC output power (cloud "pac")
+  P305_PV_POWER_IN,  // reg 1-2, total PV input power
+  P305_PV1_WATT,     // reg 5-6, PV1 power
+  P305_VAC_L2,       // reg 18
+  P305_IAC_L2,       // reg 19
+  P305_PAC_L2,       // reg 20-21, L2 power
+  P305_VAC_L3,       // reg 22
+  P305_IAC_L3,       // reg 23
+  P305_PAC_L3,       // reg 24-25, L3 power
 } eP305InputRegisters_t;
 
 void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter);

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -1,209 +1,352 @@
 #pragma once
 
-const char MAIN_page[] PROGMEM = R"=====(
+const char MAIN_page[] PROGMEM = R"rawliteral(
 <!DOCTYPE HTML>
-<html lang="en">
-
-<!-- Rui Santos - Complete project details at https://RandomNerdTutorials.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files.
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software. -->
-
+<html lang="en" data-theme="light">
 <head>
-    <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Growatt Inverter</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js" integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
-    <style>
-        body {
-            min-width: 310px;
-            max-width: 800px;
-            height: 400px;
-            margin: 0 auto;
-            font-family: Arial;
-        }
-
-        h2 {
-            font-size: 2.5rem;
-            text-align: center;
-        }
-
-        div {
-            font-size: 1rem;
-            padding: 10px 0px 10px 0px;
-        }
-
-        .linkButtonBar {
-            text-align: center;
-            padding: 20px 0px 20px 0px;
-        }
-
-        .linkButton {
-            -webkit-border-radius: 4px;
-            -moz-border-radius: 4px;
-            border-radius: 4px;
-            border: solid 1px #91ca5f;
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background: #6eb92b;
-            color: #FFF;
-            padding: 8px 12px;
-            text-decoration: none;
-            display: inline-block;
-            margin: 2px;
-            font-size: .8rem;
-            text-align: center;
-        }
-
-        .yellow {
-            border: solid 1px rgb(202, 189, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 178, 43);
-        }
-
-        .red {
-            border: solid 1px rgb(202, 95, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 43, 43);
-        }
-    </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Growatt Inverter</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+  onerror="document.body.classList.add('no-cdn')">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js"
+  integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw=="
+  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<style>
+  /* Tab bar */
+  .tabs{display:flex;gap:0;border-bottom:2px solid #ccc;margin-bottom:1rem}
+  .tabs button{background:none;border:none;padding:.6rem 1.2rem;cursor:pointer;
+    font-size:.95rem;border-bottom:3px solid transparent;color:#555}
+  .tabs button.active{border-bottom-color:#1a73e8;color:#1a73e8;font-weight:600}
+  .tabs button:hover{color:#1a73e8}
+  .tab-content{display:none}
+  .tab-content.active{display:block}
+  /* Status badges */
+  .badge{display:inline-block;padding:.15em .5em;border-radius:4px;font-size:.85rem;font-weight:600;color:#fff}
+  .badge-ok{background:#2e7d32}
+  .badge-warn{background:#ed6c02}
+  .badge-err{background:#d32f2f}
+  .badge-off{background:#757575}
+  /* Config form */
+  .cfg-msg{padding:.5rem;border-radius:4px;margin-bottom:.5rem;display:none}
+  .cfg-msg.ok{display:block;background:#e8f5e9;color:#2e7d32}
+  .cfg-msg.err{display:block;background:#ffebee;color:#c62828}
+  /* Debug iframe */
+  .debug-frame{width:100%;height:500px;border:1px solid #ccc;border-radius:4px}
+  /* Fallback CSS when CDN is offline */
+  .no-cdn{font-family:system-ui,-apple-system,sans-serif;max-width:900px;margin:0 auto;padding:1rem}
+  .no-cdn h1{font-size:1.6rem}
+  .no-cdn table{width:100%;border-collapse:collapse;margin:.5rem 0}
+  .no-cdn th,.no-cdn td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid #ddd}
+  .no-cdn input,.no-cdn select{padding:.3rem .5rem;border:1px solid #aaa;border-radius:3px;width:100%;box-sizing:border-box}
+  .no-cdn button[type=submit]{background:#1a73e8;color:#fff;border:none;padding:.5rem 1.5rem;border-radius:4px;cursor:pointer}
+  .no-cdn details{border:1px solid #ddd;border-radius:4px;padding:.5rem;margin:.5rem 0}
+  .no-cdn summary{cursor:pointer;font-weight:600}
+</style>
 </head>
-
 <body>
-    <h2>Growatt Inverter</h2>
+<main class="container">
+<h1>Growatt Inverter</h1>
 
-    <div><canvas id="powerChart"></canvas></div>
+<nav class="tabs">
+  <button class="active" data-tab="dash">Dashboard</button>
+  <button data-tab="cfg">Config</button>
+  <button data-tab="cloud">Cloud</button>
+  <button data-tab="dbg">Debug Log</button>
+  <button data-tab="sys">System</button>
+</nav>
 
-    <div class="linkButtonBar">
-        <a href="./status" class="linkButton">Json</a>
-        <a href="./uiStatus" class="linkButton">UI Json</a>
-        <a href="./metrics" class="linkButton">Metrics</a>
-        <a href="./debug" class="linkButton">Log</a>
-        <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp" class="linkButton yellow">Start Config AP</a>
-        <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot" class="linkButton yellow">Reboot</a>
-        <a href="./postCommunicationModbus" class="linkButton red">RW Modbus</a>
-    </div>
+<!-- ===== Dashboard Tab ===== -->
+<section id="tab-dash" class="tab-content active">
+  <div><canvas id="powerChart"></canvas></div>
+  <div id="DataContainer"></div>
+</section>
 
-    <div id="DataContainer"></div>
+<!-- ===== Config Tab ===== -->
+<section id="tab-cfg" class="tab-content">
+  <div id="cfgMsg" class="cfg-msg"></div>
+  <form id="cfgForm">
+    <details open>
+      <summary>Network</summary>
+      <label>Hostname <input name="hostname" id="c_hostname"></label>
+      <label>Static IP <input name="static_ip" id="c_static_ip" placeholder="leave blank for DHCP"></label>
+      <label>Netmask <input name="static_netmask" id="c_static_netmask"></label>
+      <label>Gateway <input name="static_gateway" id="c_static_gateway"></label>
+      <label>DNS <input name="static_dns" id="c_static_dns"></label>
+    </details>
+    <details>
+      <summary>MQTT</summary>
+      <label>Server <input name="mqtt_server" id="c_mqtt_server" placeholder="leave blank to disable"></label>
+      <label>Port <input name="mqtt_port" id="c_mqtt_port"></label>
+      <label>Topic <input name="mqtt_topic" id="c_mqtt_topic"></label>
+      <label>Username <input name="mqtt_user" id="c_mqtt_user"></label>
+      <label>Password <input name="mqtt_pwd" type="password" id="c_mqtt_pwd" placeholder="unchanged if blank"></label>
+      <small id="c_mqtt_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Growatt Cloud</summary>
+      <label>Datalogger Serial <input name="cloud_serial" id="c_cloud_serial" placeholder="from stick label"></label>
+      <label>Server <input name="cloud_server" id="c_cloud_server" placeholder="server.growatt.com"></label>
+    </details>
+    <details>
+      <summary>Authentication</summary>
+      <label>Username <input name="auth_user" id="c_auth_user" placeholder="blank = no auth"></label>
+      <label>Password <input name="auth_pass" type="password" id="c_auth_pass" placeholder="unchanged if blank"></label>
+      <small id="c_auth_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Advanced</summary>
+      <label>Syslog IP <input name="syslog_ip" id="c_syslog_ip" placeholder="leave blank for none"></label>
+    </details>
+    <label><input type="checkbox" name="restart" value="1"> Restart after saving</label>
+    <button type="submit">Save Configuration</button>
+  </form>
+</section>
+
+<!-- ===== Cloud Tab ===== -->
+<section id="tab-cloud" class="tab-content">
+  <table id="cloudTable" role="grid">
+    <tbody>
+      <tr><th>Status</th><td id="cl_state">--</td></tr>
+      <tr><th>Serial</th><td id="cl_serial">--</td></tr>
+      <tr><th>Server</th><td id="cl_server">--</td></tr>
+      <tr><th>Packets Sent</th><td id="cl_sent">--</td></tr>
+      <tr><th>Packets Received</th><td id="cl_recv">--</td></tr>
+      <tr><th>Reconnects</th><td id="cl_recon">--</td></tr>
+      <tr><th>Last Send</th><td id="cl_last">--</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ===== Debug Log Tab ===== -->
+<section id="tab-dbg" class="tab-content">
+  <p>WebSerial debug stream (port 8080):</p>
+  <iframe id="debugFrame" class="debug-frame"></iframe>
+</section>
+
+<!-- ===== System Tab ===== -->
+<section id="tab-sys" class="tab-content">
+  <table id="sysTable" role="grid">
+    <tbody>
+      <tr><th>Hostname</th><td id="s_host">--</td></tr>
+      <tr><th>IP Address</th><td id="s_ip">--</td></tr>
+      <tr><th>Gateway</th><td id="s_gw">--</td></tr>
+      <tr><th>Netmask</th><td id="s_mask">--</td></tr>
+      <tr><th>DNS</th><td id="s_dns">--</td></tr>
+      <tr><th>WiFi SSID</th><td id="s_ssid">--</td></tr>
+      <tr><th>WiFi RSSI</th><td id="s_rssi">--</td></tr>
+      <tr><th>MAC Address</th><td id="s_mac">--</td></tr>
+      <tr><th>Free Heap</th><td id="s_heap">--</td></tr>
+      <tr><th>Uptime</th><td id="s_up">--</td></tr>
+      <tr><th>Stick Type</th><td id="s_stick">--</td></tr>
+    </tbody>
+  </table>
+  <h4>Quick Links</h4>
+  <p>
+    <a href="./status" role="button" class="outline">JSON</a>
+    <a href="./uiStatus" role="button" class="outline">UI JSON</a>
+    <a href="./metrics" role="button" class="outline">Prometheus</a>
+    <a href="./postCommunicationModbus" role="button" class="outline secondary">RW Modbus</a>
+  </p>
+  <h4>Maintenance</h4>
+  <p>
+    <a href="./update" role="button" class="outline">Firmware Update</a>
+    <a href="#" role="button" class="outline contrast" id="btnAp"
+       onclick="if(confirm('Starting config AP will disconnect you. Continue?'))location='./startAp';return false;">Start Config AP</a>
+    <a href="#" role="button" class="outline contrast" id="btnReboot"
+       onclick="if(confirm('Reboot the WiFi stick?'))location='./reboot';return false;">Reboot</a>
+  </p>
+</section>
 
 <script>
-    let initialised = false;
-    const powerchartelement = document.getElementById('powerChart');
-
-    const CHART_COLORS = {
-        red: 'rgb(255, 99, 132)',
-        orange: 'rgb(255, 159, 64)',
-        yellow: 'rgb(255, 205, 86)',
-        green: 'rgb(75, 192, 192)',
-        blue: 'rgb(54, 162, 235)',
-        purple: 'rgb(153, 102, 255)',
-        grey: 'rgb(201, 203, 207)'
-    };
-
-    const NAMED_COLORS = [
-        CHART_COLORS.red,
-        CHART_COLORS.orange,
-        CHART_COLORS.yellow,
-        CHART_COLORS.green,
-        CHART_COLORS.blue,
-        CHART_COLORS.purple,
-        CHART_COLORS.grey,
-    ];
-
-    function namedColor(index) {
-        return NAMED_COLORS[index % NAMED_COLORS.length];
+/* ---- Tab switching ---- */
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    document.querySelectorAll('.tabs button').forEach(function(b){b.classList.remove('active')});
+    document.querySelectorAll('.tab-content').forEach(function(t){t.classList.remove('active')});
+    btn.classList.add('active');
+    var target = document.getElementById('tab-' + btn.getAttribute('data-tab'));
+    target.classList.add('active');
+    /* Lazy-load debug iframe */
+    if(btn.getAttribute('data-tab')==='dbg'){
+      var fr = document.getElementById('debugFrame');
+      if(!fr.src || fr.src===''){
+        fr.src = 'http://' + location.hostname + ':8080/';
+      }
     }
+    /* Fetch config when switching to config tab */
+    if(btn.getAttribute('data-tab')==='cfg') loadConfig();
+    /* Fetch system status */
+    if(btn.getAttribute('data-tab')==='sys') fetchSystem();
+  });
+});
 
-    const powerchartData = {
-        labels: [],
-        datasets: [],
-    };
-
-    let powerchart = new Chart(powerchartelement, {
-        type: 'line',
-        data: powerchartData,
-        options: {
-            scales: {
-                y: {
-                    beginAtZero: true
-                }
-            }
+/* ---- Dashboard: Chart.js + uiStatus polling (preserved from original) ---- */
+var initialised = false;
+var powerchartelement = document.getElementById('powerChart');
+var CHART_COLORS = {
+  red:'rgb(255,99,132)', orange:'rgb(255,159,64)', yellow:'rgb(255,205,86)',
+  green:'rgb(75,192,192)', blue:'rgb(54,162,235)', purple:'rgb(153,102,255)', grey:'rgb(201,203,207)'
+};
+var NAMED_COLORS = [CHART_COLORS.red, CHART_COLORS.orange, CHART_COLORS.yellow,
+  CHART_COLORS.green, CHART_COLORS.blue, CHART_COLORS.purple, CHART_COLORS.grey];
+function namedColor(i){return NAMED_COLORS[i % NAMED_COLORS.length]}
+var powerchartData = {labels:[], datasets:[]};
+var powerchart = new Chart(powerchartelement, {
+  type:'line', data:powerchartData,
+  options:{scales:{y:{beginAtZero:true}}}
+});
+setInterval(function(){
+  var xhttp = new XMLHttpRequest();
+  xhttp.onreadystatechange = function(){
+    if(this.readyState==4 && this.status==200){
+      var obj = JSON.parse(this.responseText);
+      var date = new Date();
+      powerchartData.labels.push(date.getHours()+":"+date.getMinutes()+":"+date.getSeconds());
+      if(initialised==false){
+        initialised = true;
+        var container = document.getElementById("DataContainer");
+        container.innerHTML = "";
+        for(var key in obj){
+          if(obj[key][2]==true){
+            var nd = {label:key, data:[obj[key][0]], fill:false,
+              borderColor:namedColor(powerchart.data.datasets.length), tension:0.1};
+            powerchartData.datasets.push(nd);
+            powerchart.update();
+          }
+          var el = document.createElement("p");
+          el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          el.setAttribute("id", key);
+          container.appendChild(el);
         }
-    });
-
-    setInterval(function () {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function () {
-            if (this.readyState == 4 && this.status == 200) {
-                // add data fields to the main page
-                var obj = JSON.parse(this.responseText);
-                // Add Date to chart x Axis
-                let date = new Date();
-                powerchartData.labels.push(date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds());
-                if (initialised == false) {
-                    initialised = true;
-                    // clear data view container just in case
-                    container = document.getElementById("DataContainer");
-                    container.innerHTML = "";
-                    // Add Data Labels to chart
-                    for (var key in obj) {
-                        if (obj[key][2] == true) {
-                            const newDataset = {
-                                label: key,
-                                data: [obj[key][0]],
-                                fill: false,
-                                borderColor: namedColor(powerchart.data.datasets.length),
-                                tension: 0.1
-                            };
-                            powerchartData.datasets.push(newDataset);
-                            powerchart.update();
-                        }
-                        // init dataview
-                        var element = document.createElement("p");
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        element.setAttribute("id", key);
-                        container.appendChild(element);
-                    }
-                } else {
-                    // Update Data in chart
-                    for (var key in obj) {
-                        // find dataset in array
-                        if (obj[key][2] == true) {
-                            for (var dset in powerchartData.datasets) {
-                                let leb = powerchartData.datasets[dset].label;
-                                if (leb == key) {
-                                    powerchartData.datasets[dset].data.push(obj[key][0]);
-                                }
-                            }
-                        }
-                        // update data view
-                        var element = document.getElementById(key);
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        powerchart.update();
-                    }
-                }
+      } else {
+        for(var key in obj){
+          if(obj[key][2]==true){
+            for(var d in powerchartData.datasets){
+              if(powerchartData.datasets[d].label==key){
+                powerchartData.datasets[d].data.push(obj[key][0]);
+              }
             }
+          }
+          var el = document.getElementById(key);
+          if(el) el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          powerchart.update();
         }
-        xhttp.open("GET", "./uiStatus", true);
-        xhttp.send();
-    }, 5000);
+      }
+    }
+  };
+  xhttp.open("GET","./uiStatus",true);
+  xhttp.send();
+}, 5000);
+
+/* ---- Config tab ---- */
+function loadConfig(){
+  fetch('./config').then(function(r){return r.json()}).then(function(d){
+    var fields = ['hostname','static_ip','static_netmask','static_gateway','static_dns',
+      'mqtt_server','mqtt_port','mqtt_topic','mqtt_user','cloud_serial','cloud_server',
+      'auth_user','syslog_ip'];
+    for(var i=0;i<fields.length;i++){
+      var el = document.getElementById('c_'+fields[i]);
+      if(el && d[fields[i]]!==undefined) el.value = d[fields[i]];
+    }
+    var mh = document.getElementById('c_mqtt_pwd_hint');
+    if(mh) mh.textContent = d.mqtt_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+    var ah = document.getElementById('c_auth_pwd_hint');
+    if(ah) ah.textContent = d.auth_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+  }).catch(function(e){
+    showCfgMsg('Failed to load config: '+e, true);
+  });
+}
+
+document.getElementById('cfgForm').addEventListener('submit', function(ev){
+  ev.preventDefault();
+  var msg = document.getElementById('cfgMsg');
+  msg.className = 'cfg-msg';
+  msg.textContent = 'Saving...';
+  msg.style.display = 'block';
+  fetch('./saveConfig', {
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+    body: new URLSearchParams(new FormData(this))
+  }).then(function(r){return r.json()}).then(function(d){
+    if(d.ok){
+      showCfgMsg(d.restart ? 'Saved! Restarting device...' : 'Configuration saved.', false);
+    } else {
+      showCfgMsg('Save failed.', true);
+    }
+  }).catch(function(e){
+    showCfgMsg('Error: '+e, true);
+  });
+});
+
+function showCfgMsg(text, isErr){
+  var el = document.getElementById('cfgMsg');
+  el.className = 'cfg-msg ' + (isErr ? 'err' : 'ok');
+  el.textContent = text;
+}
+
+/* ---- Cloud tab polling ---- */
+var cloudInterval = null;
+function fetchCloud(){
+  fetch('./cloudStatus').then(function(r){return r.json()}).then(function(d){
+    if(d.supported===false){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Not compiled</span>';
+      return;
+    }
+    if(!d.enabled){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Disabled</span>';
+      document.getElementById('cl_serial').textContent = 'Not configured';
+      return;
+    }
+    var sc = d.stateCode || 0;
+    var bc = sc >= 3 ? 'badge-ok' : (sc >= 1 ? 'badge-warn' : 'badge-err');
+    if(sc === 5) bc = 'badge-err';
+    document.getElementById('cl_state').innerHTML = '<span class="badge '+bc+'">'+d.state+'</span>';
+    document.getElementById('cl_serial').textContent = d.serial || '--';
+    document.getElementById('cl_server').textContent = d.server || '--';
+    document.getElementById('cl_sent').textContent = d.packetsSent;
+    document.getElementById('cl_recv').textContent = d.packetsRecv;
+    document.getElementById('cl_recon').textContent = d.reconnects;
+    document.getElementById('cl_last').textContent = d.lastSendAgo >= 0 ? d.lastSendAgo+'s ago' : 'never';
+  }).catch(function(){});
+}
+
+/* Start/stop cloud polling based on tab visibility */
+var origTabClick = null;
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    if(btn.getAttribute('data-tab')==='cloud'){
+      fetchCloud();
+      if(!cloudInterval) cloudInterval = setInterval(fetchCloud, 10000);
+    } else {
+      if(cloudInterval){clearInterval(cloudInterval); cloudInterval=null;}
+    }
+  });
+});
+
+/* ---- System tab ---- */
+function fetchSystem(){
+  fetch('./systemStatus').then(function(r){return r.json()}).then(function(d){
+    document.getElementById('s_host').textContent = d.hostname || '--';
+    document.getElementById('s_ip').textContent = d.ip || '--';
+    document.getElementById('s_gw').textContent = d.gateway || '--';
+    document.getElementById('s_mask').textContent = d.netmask || '--';
+    document.getElementById('s_dns').textContent = d.dns || '--';
+    document.getElementById('s_ssid').textContent = d.ssid || '--';
+    document.getElementById('s_mac').textContent = d.mac || '--';
+    document.getElementById('s_rssi').textContent = (d.rssi || 0) + ' dBm';
+    document.getElementById('s_heap').textContent = d.heap ? (d.heap + ' bytes') : '--';
+    var up = d.uptime || 0;
+    var h = Math.floor(up/3600); var m = Math.floor((up - h*3600)/60); var s = up - h*3600 - m*60;
+    document.getElementById('s_up').textContent = h+'h '+m+'m '+s+'s';
+    document.getElementById('s_stick').textContent = d.stickType || '--';
+  }).catch(function(){});
+}
 </script>
+</main>
 </body>
 </html>
-)=====";
+)rawliteral";
 
 const char SendPostSite_page[] PROGMEM = R"=====(
 <!DOCTYPE HTML><html>

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -155,14 +155,14 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
         <td><button onclick="setParam('pv_power_factor',document.getElementById('set_pf').value)">Apply</button></td>
       </tr>
       <tr>
-        <td>Grid Voltage High Limit (V) <small>(HR 23)</small></td>
+        <td>Grid Voltage High Limit (V) <small>(⚠ unverified register)</small></td>
         <td><input id="set_vhi" type="number" step="0.1" value=""></td>
-        <td><button onclick="setParam('pv_grid_voltage_high',document.getElementById('set_vhi').value)">Apply</button></td>
+        <td><button onclick="setParamDangerous('pv_grid_voltage_high',document.getElementById('set_vhi').value,'Grid Voltage HIGH limit')">Apply</button></td>
       </tr>
       <tr>
-        <td>Grid Voltage Low Limit (V) <small>(HR 24)</small></td>
+        <td>Grid Voltage Low Limit (V) <small>(⚠ unverified register)</small></td>
         <td><input id="set_vlo" type="number" step="0.1" value=""></td>
-        <td><button onclick="setParam('pv_grid_voltage_low',document.getElementById('set_vlo').value)">Apply</button></td>
+        <td><button onclick="setParamDangerous('pv_grid_voltage_low',document.getElementById('set_vlo').value,'Grid Voltage LOW limit')">Apply</button></td>
       </tr>
       <tr>
         <td>Set Time <small>(HR 45-50)</small></td>
@@ -352,6 +352,16 @@ function setParam(type, val1, val2){
     .then(function(r){return r.text();})
     .then(function(t){ msg.textContent = t; })
     .catch(function(e){ msg.textContent = 'Request failed: ' + e; });
+}
+function setParamDangerous(type, val1, label){
+  if(!val1){ alert('Enter a value first'); return; }
+  var prompt1 = 'CAUTION: ' + label + ' = ' + val1 + ' V\n\n' +
+    'Wrong values can trip the inverter offline or damage the grid connection.\n' +
+    'Also: this register address is NOT verified — the firmware will refuse\n' +
+    'the write unless explicitly enabled in the backend.\n\nProceed?';
+  if(!confirm(prompt1)) return;
+  if(!confirm('Are you ABSOLUTELY sure? Type Yes again to confirm.')) return;
+  setParam(type, val1);
 }
 
 /* ---- Cloud tab polling ---- */

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -155,14 +155,14 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
         <td><button onclick="setParam('pv_power_factor',document.getElementById('set_pf').value)">Apply</button></td>
       </tr>
       <tr>
-        <td>Grid Voltage High Limit (V) <small>(⚠ unverified register)</small></td>
-        <td><input id="set_vhi" type="number" step="0.1" value=""></td>
-        <td><button onclick="setParamDangerous('pv_grid_voltage_high',document.getElementById('set_vhi').value,'Grid Voltage HIGH limit')">Apply</button></td>
+        <td>Grid Voltage HIGH Limit (V L-L) <small>(HR 20, EN50438 default: 440.0 = 400×1.10)</small></td>
+        <td><input id="set_vhi" type="number" step="0.1" min="380" max="500" value="440.0"></td>
+        <td><button onclick="setParamDangerous('pv_grid_voltage_high',document.getElementById('set_vhi').value,'Grid Voltage HIGH limit (line-to-line)')">Apply</button></td>
       </tr>
       <tr>
-        <td>Grid Voltage Low Limit (V) <small>(⚠ unverified register)</small></td>
-        <td><input id="set_vlo" type="number" step="0.1" value=""></td>
-        <td><button onclick="setParamDangerous('pv_grid_voltage_low',document.getElementById('set_vlo').value,'Grid Voltage LOW limit')">Apply</button></td>
+        <td>Grid Voltage LOW Limit (V L-L) <small>(HR 19, EN50438 default: 338.0 = 195.5×√3)</small></td>
+        <td><input id="set_vlo" type="number" step="0.1" min="280" max="400" value="338.0"></td>
+        <td><button onclick="setParamDangerous('pv_grid_voltage_low',document.getElementById('set_vlo').value,'Grid Voltage LOW limit (line-to-line)')">Apply</button></td>
       </tr>
       <tr>
         <td>Set Time <small>(HR 45-50)</small></td>
@@ -356,11 +356,12 @@ function setParam(type, val1, val2){
 function setParamDangerous(type, val1, label){
   if(!val1){ alert('Enter a value first'); return; }
   var prompt1 = 'CAUTION: ' + label + ' = ' + val1 + ' V\n\n' +
-    'Wrong values can trip the inverter offline or damage the grid connection.\n' +
-    'Also: this register address is NOT verified — the firmware will refuse\n' +
-    'the write unless explicitly enabled in the backend.\n\nProceed?';
+    'Changes the inverter\'s grid protection trip point. Wrong values can\n' +
+    'take the inverter offline or violate your grid operator\'s rules.\n\n' +
+    'EN50438 defaults: LOW 338 V (L-L), HIGH 440 V (L-L).\n\n' +
+    'Proceed?';
   if(!confirm(prompt1)) return;
-  if(!confirm('Are you ABSOLUTELY sure? Type Yes again to confirm.')) return;
+  if(!confirm('Confirm once more to apply.')) return;
   setParam(type, val1);
 }
 

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -52,6 +52,7 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
   <button class="active" data-tab="dash">Dashboard</button>
   <button data-tab="cfg">Config</button>
   <button data-tab="cloud">Cloud</button>
+  <button data-tab="ctrl">Set</button>
   <button data-tab="dbg">Debug Log</button>
   <button data-tab="sys">System</button>
 </nav>
@@ -116,6 +117,61 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
       <tr><th>Last Send</th><td id="cl_last">--</td></tr>
     </tbody>
   </table>
+</section>
+
+<!-- ===== Set / Control Tab ===== -->
+<section id="tab-ctrl" class="tab-content">
+  <p><small>Direct Modbus writes — same parameters as the Shine portal Set commands, but
+  applied immediately over RS-485 without going through Growatt's cloud.</small></p>
+  <table role="grid">
+    <thead><tr><th>Parameter</th><th>Value</th><th></th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Inverter On/Off <small>(HR 0)</small></td>
+        <td><select id="set_onoff"><option value="1">On</option><option value="0">Off</option></select></td>
+        <td><button onclick="setParam('pv_on_off',document.getElementById('set_onoff').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>PF Memory <small>(HR 2)</small></td>
+        <td><select id="set_pfmem"><option value="1">On</option><option value="0">Off</option></select></td>
+        <td><button onclick="setParam('pv_pf_cmd_memory_state',document.getElementById('set_pfmem').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Active Power Rate (%) <small>(HR 3)</small></td>
+        <td><input id="set_actrate" type="number" min="0" max="100" value="100"></td>
+        <td><button onclick="setParam('pv_active_p_rate',document.getElementById('set_actrate').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Reactive Power Rate (%) <small>(HR 4)</small></td>
+        <td>
+          <select id="set_reactdir"><option value="over">Inductive</option><option value="under">Capacitive</option></select>
+          <input id="set_reactrate" type="number" min="0" max="100" value="0" style="width:80px">
+        </td>
+        <td><button onclick="setParam('pv_reactive_p_rate',document.getElementById('set_reactrate').value,document.getElementById('set_reactdir').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Power Factor <small>(HR 5, -1..-0.8 / 0.8..1)</small></td>
+        <td><input id="set_pf" type="number" step="0.01" min="-1" max="1" value="1.0"></td>
+        <td><button onclick="setParam('pv_power_factor',document.getElementById('set_pf').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Grid Voltage High Limit (V) <small>(HR 23)</small></td>
+        <td><input id="set_vhi" type="number" step="0.1" value=""></td>
+        <td><button onclick="setParam('pv_grid_voltage_high',document.getElementById('set_vhi').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Grid Voltage Low Limit (V) <small>(HR 24)</small></td>
+        <td><input id="set_vlo" type="number" step="0.1" value=""></td>
+        <td><button onclick="setParam('pv_grid_voltage_low',document.getElementById('set_vlo').value)">Apply</button></td>
+      </tr>
+      <tr>
+        <td>Set Time <small>(HR 45-50)</small></td>
+        <td></td>
+        <td><button onclick="setParam('pf_sys_year','now')">Sync to now</button></td>
+      </tr>
+    </tbody>
+  </table>
+  <p id="set_result"></p>
 </section>
 
 <!-- ===== Debug Log Tab ===== -->
@@ -283,6 +339,19 @@ function showCfgMsg(text, isErr){
   var el = document.getElementById('cfgMsg');
   el.className = 'cfg-msg ' + (isErr ? 'err' : 'ok');
   el.textContent = text;
+}
+
+/* ---- Set / Control tab ---- */
+function setParam(type, val1, val2){
+  var msg = document.getElementById('set_result');
+  msg.textContent = 'Working...';
+  var body = 'type=' + encodeURIComponent(type) +
+             '&val1=' + encodeURIComponent(val1 || '') +
+             '&val2=' + encodeURIComponent(val2 || '');
+  fetch('./setParam', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body:body})
+    .then(function(r){return r.text();})
+    .then(function(t){ msg.textContent = t; })
+    .catch(function(e){ msg.textContent = 'Request failed: ' + e; });
 }
 
 /* ---- Cloud tab polling ---- */

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -8,7 +8,7 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Growatt Inverter</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
-  onerror="document.body.classList.add('no-cdn')">
+  onerror="document.documentElement.classList.add('no-cdn')">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js"
   integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw=="
   crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -312,7 +312,6 @@ function fetchCloud(){
 }
 
 /* Start/stop cloud polling based on tab visibility */
-var origTabClick = null;
 document.querySelectorAll('.tabs button').forEach(function(btn){
   btn.addEventListener('click', function(){
     if(btn.getAttribute('data-tab')==='cloud'){

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -542,6 +542,7 @@ void setup() {
 #endif
   httpServer.on("/config", HTTP_GET, sendConfigJson);
   httpServer.on("/saveConfig", HTTP_POST, handleSaveConfig);
+  httpServer.on("/setParam", HTTP_POST, handleSetParam);
   httpServer.on("/cloudStatus", sendCloudStatus);
   httpServer.on("/systemStatus", sendSystemStatus);
   httpServer.on("/update", HTTP_GET, sendUpdatePage);
@@ -1075,6 +1076,100 @@ void handleSaveConfig(void) {
     delay(1000);
     ESP.restart();
   }
+}
+
+// Local Set Inverter Param — mirrors the Shine portal Set commands, but
+// applies the writes directly via Modbus instead of routing through Growatt
+// cloud. Each paramId maps to one or two holding-register writes that the
+// reverse-engineered cloud protocol uses for the same action.
+void handleSetParam(void) {
+  if (!checkAuth()) return;
+  if (!httpServer.hasArg(F("type"))) {
+    httpServer.send(400, F("text/plain"), F("missing type"));
+    return;
+  }
+  String type = httpServer.arg(F("type"));
+  String v1 = httpServer.hasArg(F("val1")) ? httpServer.arg(F("val1")) : String();
+  String v2 = httpServer.hasArg(F("val2")) ? httpServer.arg(F("val2")) : String();
+
+  auto write1 = [](uint16_t reg, uint16_t val, char* out, size_t outlen) -> bool {
+    bool ok = Inverter.WriteHoldingReg(reg, val);
+    snprintf(out, outlen, "HR %u = %u : %s", (unsigned)reg, (unsigned)val,
+             ok ? "OK" : "Modbus write failed");
+    return ok;
+  };
+
+  char msg[128];
+  bool ok = false;
+
+  if (type == "pv_on_off") {
+    ok = write1(0, (uint16_t)v1.toInt() ? 1 : 0, msg, sizeof(msg));
+  } else if (type == "pv_pf_cmd_memory_state") {
+    ok = write1(2, (uint16_t)v1.toInt() ? 1 : 0, msg, sizeof(msg));
+  } else if (type == "pv_active_p_rate") {
+    int pct = v1.toInt();
+    if (pct < 0 || pct > 100) {
+      httpServer.send(400, F("text/plain"), F("rate must be 0..100"));
+      return;
+    }
+    ok = write1(3, (uint16_t)pct, msg, sizeof(msg));
+  } else if (type == "pv_reactive_p_rate") {
+    int pct = v1.toInt();
+    if (pct < 0 || pct > 100) {
+      httpServer.send(400, F("text/plain"), F("rate must be 0..100"));
+      return;
+    }
+    bool wroteRate = Inverter.WriteHoldingReg(4, (uint16_t)pct);
+    // dir: cloud uses reg 99 = 4 for Inductive ("over"), 5 for Capacitive ("under")
+    uint16_t dirVal = (v2 == "under") ? 5 : 4;
+    bool wroteDir = Inverter.WriteHoldingReg(99, dirVal);
+    ok = wroteRate && wroteDir;
+    snprintf(msg, sizeof(msg), "HR 4 = %d, HR 99 = %u : %s", pct, dirVal,
+             ok ? "OK" : "Modbus write failed");
+  } else if (type == "pv_power_factor") {
+    float pf = v1.toFloat();
+    if (pf < -1.0f || pf > 1.0f || (pf > -0.8f && pf < 0.8f)) {
+      httpServer.send(400, F("text/plain"), F("PF must be -1..-0.8 or 0.8..1"));
+      return;
+    }
+    bool wroteMode = Inverter.WriteHoldingReg(99, 1);
+    uint16_t scaled = (uint16_t)(pf * 20000.0f);
+    bool wrotePf = Inverter.WriteHoldingReg(5, scaled);
+    ok = wroteMode && wrotePf;
+    snprintf(msg, sizeof(msg), "HR 99 = 1, HR 5 = %u (PF=%.2f) : %s",
+             scaled, pf, ok ? "OK" : "Modbus write failed");
+  } else if (type == "pv_grid_voltage_high") {
+    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
+    uint16_t raw = (uint16_t)(v1.toFloat() * 10.0f);  // /10 multiplier per Growatt convention
+    ok = write1(23, raw, msg, sizeof(msg));
+  } else if (type == "pv_grid_voltage_low") {
+    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
+    uint16_t raw = (uint16_t)(v1.toFloat() * 10.0f);
+    ok = write1(24, raw, msg, sizeof(msg));
+  } else if (type == "pf_sys_year") {
+    time_t now = time(nullptr);
+    struct tm* lt = localtime(&now);
+    if (!lt || lt->tm_year < 120) {  // sanity: 2020 or later
+      httpServer.send(503, F("text/plain"), F("system time not synced"));
+      return;
+    }
+    bool a = Inverter.WriteHoldingReg(45, (uint16_t)(lt->tm_year - 100));  // year-2000
+    bool b = Inverter.WriteHoldingReg(46, (uint16_t)(lt->tm_mon + 1));
+    bool c = Inverter.WriteHoldingReg(47, (uint16_t)lt->tm_mday);
+    bool d = Inverter.WriteHoldingReg(48, (uint16_t)lt->tm_hour);
+    bool e = Inverter.WriteHoldingReg(49, (uint16_t)lt->tm_min);
+    bool f = Inverter.WriteHoldingReg(50, (uint16_t)lt->tm_sec);
+    ok = a && b && c && d && e && f;
+    snprintf(msg, sizeof(msg), "HR 45-50 = %04d-%02d-%02d %02d:%02d:%02d : %s",
+             lt->tm_year + 1900, lt->tm_mon + 1, lt->tm_mday,
+             lt->tm_hour, lt->tm_min, lt->tm_sec, ok ? "OK" : "partial fail");
+  } else {
+    httpServer.send(400, F("text/plain"), F("unknown type"));
+    return;
+  }
+
+  Log.printf("[setParam] %s -> %s\n", type.c_str(), msg);
+  httpServer.send(ok ? 200 : 500, F("text/plain"), msg);
 }
 
 void sendCloudStatus(void) {

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -1138,18 +1138,38 @@ void handleSetParam(void) {
     ok = wroteMode && wrotePf;
     snprintf(msg, sizeof(msg), "HR 99 = 1, HR 5 = %u (PF=%.2f) : %s",
              scaled, pf, ok ? "OK" : "Modbus write failed");
-  } else if (type == "pv_grid_voltage_high" || type == "pv_grid_voltage_low") {
-    // Holding regs 23-27 are the inverter serial (ASCII), NOT voltage limits.
-    // The cloud's real `pv_grid_voltage_high/low` register addresses haven't
-    // been captured yet (we intentionally skipped exercising them since
-    // wrong values can take the inverter offline). Refuse for safety until
-    // a real cloud-side WRITE_REG is observed and recorded here.
-    httpServer.send(503, F("text/plain"),
-        F("Voltage limit registers not verified yet. Trigger this command "
-          "from the Shine cloud portal once so the firmware can capture the "
-          "real register address (visible as a [GrowattCloud] WRITE_REG line "
-          "in syslog), then update handleSetParam to use it."));
-    return;
+  } else if (type == "pv_grid_voltage_low") {
+    // Both Vac limit registers on this 3-phase inverter store LINE-TO-LINE
+    // volts × 10, not L-N. The inverter measures pvgridvoltage/2/3 as L-L
+    // (~420 V each phase pair on nominal 400 V grid).
+    // EN50438 -15%: 195.5 V L-N × √3 ≈ 338 V L-L.
+    // The Shine portal's "Set Grid Voltage Low" prompt sends the user input
+    // unchanged — entering 195 there gives 1950 raw which is effectively
+    // "trip never" (L-L would have to fall to half-nominal). Always enter L-L.
+    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
+    float vf = v1.toFloat();
+    if (vf < 280.0f || vf > 400.0f) {
+      httpServer.send(400, F("text/plain"),
+                      F("low limit must be 280..400 V (line-to-line)"));
+      return;
+    }
+    ok = write1(19, (uint16_t)(vf * 10.0f), msg, sizeof(msg));
+  } else if (type == "pv_grid_voltage_high") {
+    // HR 20 stores Vac HIGH limit in LINE-TO-LINE volts × 10 (the inverter is
+    // 3-phase, nominal L-L = 400 V = 230 V × √3). The Shine cloud's
+    // "Set Grid Voltage High" passes its input through unchanged, so the
+    // user must enter the L-L value (e.g. 440 V = EN50438 +10%, not 253 V L-N).
+    // Verified scaling 2026-05-29: read HR 20 = 4382 ≈ 438 V L-L = factory
+    // setting roughly matching EN50438. Writing a value below ~400 V L-L is
+    // rejected at the Modbus layer.
+    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
+    float vf = v1.toFloat();
+    if (vf < 380.0f || vf > 500.0f) {
+      httpServer.send(400, F("text/plain"),
+                      F("high limit must be 380..500 V (line-to-line)"));
+      return;
+    }
+    ok = write1(20, (uint16_t)(vf * 10.0f), msg, sizeof(msg));
   } else if (type == "pf_sys_year") {
     time_t now = time(nullptr);
     struct tm* lt = localtime(&now);

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -1281,24 +1281,68 @@ void loop() {
           handleWdtReset(mqttSuccess);
 
 #if GROWATT_CLOUD_SUPPORTED == 1
-          // Feed register data to Growatt Cloud sender
+          // Inverter serial lives in HR 23-27 as packed ASCII; set it on the
+          // cloud module once so ANNOUNCE carries the real device identifier.
+          // Without this the cloud accepts the datalogger but can't link the
+          // device to the user's account → app shows no data.
+          static bool inverterSerialSet = false;
+          if (!inverterSerialSet && !Config.cloud_serial.isEmpty()) {
+            char invSerial[11] = {0};
+            bool gotSerial = true;
+            for (int r = 0; r < 5; r++) {
+              uint16_t regVal;
+              if (Inverter.ReadHoldingReg(23 + r, &regVal)) {
+                invSerial[r * 2]     = (regVal >> 8) & 0xFF;
+                invSerial[r * 2 + 1] = regVal & 0xFF;
+              } else {
+                gotSerial = false;
+                break;
+              }
+            }
+            if (gotSerial && invSerial[0] > 0x20) {
+              invSerial[10] = '\0';
+              growattCloud.setInverterSerial(invSerial);
+              inverterSerialSet = true;
+              Log.print(F("[GrowattCloud] Inverter serial: "));
+              Log.println(invSerial);
+            }
+          }
+
+          // Feed register data to Growatt Cloud sender.
+          // The cloud DATA frame indexes registers by Modbus *address*, but
+          // Inverter._Protocol.InputRegisters[i] is indexed by an arbitrary
+          // table position (e.g. v3.05 reads only 12 sparse addresses).
+          // Placing values at the wrong array slot makes the cloud parse
+          // every field at the wrong byte offset → server discards the payload
+          // silently (status=-1, pac=0). Build address-indexed arrays here.
           if (!Config.cloud_serial.isEmpty()) {
-            // Build arrays of raw register values for cloud protocol.
-            // Cap counts to the local buffer sizes so the downstream callee
-            // never reads past inputRegs[]/holdingRegs[].
-            uint16_t inputRegs[125];
-            uint16_t holdingRegs[35];
+            uint16_t inputRegs[90] = {0};
+            uint16_t holdingRegs[90] = {0};
             uint16_t numInput = Inverter._Protocol.InputRegisterCount;
             uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
-            if (numInput > 125) numInput = 125;
-            if (numHolding > 35) numHolding = 35;
             for (uint16_t i = 0; i < numInput; i++) {
-              inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
+              const sGrowattModbusReg_t& r = Inverter._Protocol.InputRegisters[i];
+              if (r.address >= 90) continue;
+              if (r.size == SIZE_32BIT || r.size == SIZE_32BIT_S) {
+                inputRegs[r.address] = (uint16_t)(r.value >> 16);
+                if (r.address + 1 < 90)
+                  inputRegs[r.address + 1] = (uint16_t)(r.value & 0xFFFF);
+              } else {
+                inputRegs[r.address] = (uint16_t)r.value;
+              }
             }
             for (uint16_t i = 0; i < numHolding; i++) {
-              holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
+              const sGrowattModbusReg_t& r = Inverter._Protocol.HoldingRegisters[i];
+              if (r.address >= 90) continue;
+              if (r.size == SIZE_32BIT || r.size == SIZE_32BIT_S) {
+                holdingRegs[r.address] = (uint16_t)(r.value >> 16);
+                if (r.address + 1 < 90)
+                  holdingRegs[r.address + 1] = (uint16_t)(r.value & 0xFFFF);
+              } else {
+                holdingRegs[r.address] = (uint16_t)r.value;
+              }
             }
-            growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);
+            growattCloud.loop(inputRegs, 90, holdingRegs, 90);
           }
 #endif
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -550,6 +550,10 @@ void setup() {
 
   Inverter.InitProtocol();
   InverterReconnect();
+  // Collect Origin and Referer so checkSameOrigin() can inspect them.
+  const char* csrfHeaders[] = {"Origin", "Referer"};
+  httpServer.collectHeaders(csrfHeaders,
+                            sizeof(csrfHeaders) / sizeof(csrfHeaders[0]));
   httpServer.begin();
 
 #if GROWATT_CLOUD_SUPPORTED == 1
@@ -581,13 +585,17 @@ void setup() {
   }
 
   if (!Config.cloud_serial.isEmpty()) {
-    GrowattCloudConfig cloudCfg;
+    GrowattCloudConfig cloudCfg = {};
     strncpy(cloudCfg.serverHost, Config.cloud_server.c_str(), sizeof(cloudCfg.serverHost) - 1);
+    cloudCfg.serverHost[sizeof(cloudCfg.serverHost) - 1] = '\0';
     cloudCfg.serverPort = GROWATT_PORT_DEFAULT;
     cloudCfg.protocolId = GROWATT_PROTO_ENC_V2;
-    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), GROWATT_SERIAL_LEN);
-    memset(cloudCfg.inverterSerial, 0, sizeof(cloudCfg.inverterSerial));
+    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(),
+            sizeof(cloudCfg.dataloggerSerial) - 1);
+    cloudCfg.dataloggerSerial[sizeof(cloudCfg.dataloggerSerial) - 1] = '\0';
+    // inverterSerial already zeroed by the {} initializer above
     strncpy(cloudCfg.fwVersion, "1.7.7.7", sizeof(cloudCfg.fwVersion) - 1);
+    cloudCfg.fwVersion[sizeof(cloudCfg.fwVersion) - 1] = '\0';
     cloudCfg.logIntervalMin = 5;
     cloudCfg.enabled = true;
     growattCloud.begin(cloudCfg);
@@ -712,6 +720,31 @@ bool checkAuth() {
   }
 #endif
   return true;
+}
+
+// CSRF mitigation for state-changing endpoints. Browsers send Basic Auth
+// credentials automatically, so a cross-site POST could otherwise reconfigure
+// the device. Require that the Origin (or Referer) header points at this
+// device. Same-origin form posts from the device's own pages always include
+// one of these; cross-site posts will not (or will point elsewhere).
+bool checkSameOrigin() {
+  String host = httpServer.hostHeader();
+  String origin = httpServer.header(F("Origin"));
+  String referer = httpServer.header(F("Referer"));
+  auto matches = [&host](const String& url) -> bool {
+    if (url.isEmpty() || host.isEmpty()) return false;
+    int schemeEnd = url.indexOf(F("://"));
+    if (schemeEnd < 0) return false;
+    int hostStart = schemeEnd + 3;
+    int hostEnd = url.indexOf('/', hostStart);
+    String urlHost = (hostEnd < 0) ? url.substring(hostStart)
+                                   : url.substring(hostStart, hostEnd);
+    return urlHost.equalsIgnoreCase(host);
+  };
+  if (!origin.isEmpty()) return matches(origin);
+  if (!referer.isEmpty()) return matches(referer);
+  // Neither header present: reject state-changing request to be safe.
+  return false;
 }
 
 void sendJson(JsonDocument& doc) {
@@ -999,6 +1032,11 @@ void sendConfigJson(void) {
 
 void handleSaveConfig(void) {
   if (!checkAuth()) return;
+  if (!checkSameOrigin()) {
+    httpServer.send(403, F("text/plain"),
+                    F("Forbidden: cross-origin request rejected"));
+    return;
+  }
   if (httpServer.hasArg(F("hostname"))) Config.hostname = httpServer.arg(F("hostname"));
   if (httpServer.hasArg(F("static_ip"))) Config.static_ip = httpServer.arg(F("static_ip"));
   if (httpServer.hasArg(F("static_netmask"))) Config.static_netmask = httpServer.arg(F("static_netmask"));
@@ -1045,9 +1083,15 @@ void sendCloudStatus(void) {
 #if GROWATT_CLOUD_SUPPORTED == 1
   if (!Config.cloud_serial.isEmpty()) {
     doc["enabled"] = true;
-    const char* stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
-    doc["state"] = stateNames[growattCloud.getState()];
-    doc["stateCode"] = (int)growattCloud.getState();
+    static const char* const stateNames[] = {"Disconnected", "Connecting",
+                                             "Connected",    "Announced",
+                                             "Active",       "Error"};
+    int sIdx = (int)growattCloud.getState();
+    doc["state"] =
+        (sIdx >= 0 && sIdx < (int)(sizeof(stateNames) / sizeof(stateNames[0])))
+            ? stateNames[sIdx]
+            : "Unknown";
+    doc["stateCode"] = sIdx;
     doc["packetsSent"] = growattCloud.getPacketsSent();
     doc["packetsRecv"] = growattCloud.getPacketsRecv();
     doc["reconnects"] = growattCloud.getReconnects();
@@ -1239,15 +1283,19 @@ void loop() {
 #if GROWATT_CLOUD_SUPPORTED == 1
           // Feed register data to Growatt Cloud sender
           if (!Config.cloud_serial.isEmpty()) {
-            // Build arrays of raw register values for cloud protocol
-            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
-            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            // Build arrays of raw register values for cloud protocol.
+            // Cap counts to the local buffer sizes so the downstream callee
+            // never reads past inputRegs[]/holdingRegs[].
             uint16_t inputRegs[125];
             uint16_t holdingRegs[35];
-            for (uint16_t i = 0; i < numInput && i < 125; i++) {
+            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
+            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            if (numInput > 125) numInput = 125;
+            if (numHolding > 35) numHolding = 35;
+            for (uint16_t i = 0; i < numInput; i++) {
               inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
             }
-            for (uint16_t i = 0; i < numHolding && i < 35; i++) {
+            for (uint16_t i = 0; i < numHolding; i++) {
               holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
             }
             growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -11,6 +11,12 @@
 #include <WiFiManager.h>
 #include <StreamUtils.h>
 
+#ifdef ESP8266
+#include <Updater.h>
+#elif defined(ESP32)
+#include <Update.h>
+#endif
+
 #ifdef ESP32
 #include <esp_task_wdt.h>
 #endif
@@ -37,6 +43,10 @@ DoubleResetDetector* drd;
 #include "ShineMqtt.h"
 #endif
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+#include "GrowattCloud.h"
+#endif
+
 #if OTA_SUPPORTED == 1
 #include <ArduinoOTA.h>
 #endif
@@ -57,6 +67,11 @@ WiFiClientSecure espClient;
 WiFiClient espClient;
 #endif
 ShineMqtt shineMqtt(espClient, Inverter);
+#endif
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+GrowattCloud growattCloud;
+WiFiClient growattCloudClient;
 #endif
 
 #ifdef AP_BUTTON_PRESSED
@@ -92,7 +107,15 @@ struct {
   WiFiManagerParameter* mqtt_user = NULL;
   WiFiManagerParameter* mqtt_pwd = NULL;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  WiFiManagerParameter* cloud_serial = NULL;
+  WiFiManagerParameter* cloud_server = NULL;
+#endif
   WiFiManagerParameter* syslog_ip = NULL;
+#if ENABLE_WEB_AUTH == 1
+  WiFiManagerParameter* auth_user = NULL;
+  WiFiManagerParameter* auth_pass = NULL;
+#endif
 } customWMParams;
 
 static const struct {
@@ -108,7 +131,15 @@ static const struct {
   const char* mqtt_user = "/mqttu";
   const char* mqtt_pwd = "/mqttw";
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  const char* cloud_serial = "/cloudsn";
+  const char* cloud_server = "/cloudsrv";
+#endif
   const char* syslog_ip = "/syslogip";
+#if ENABLE_WEB_AUTH == 1
+  const char* auth_user = "/authuser";
+  const char* auth_pass = "/authpass";
+#endif
   const char* force_ap = "/forceap";
 } ConfigFiles;
 
@@ -121,7 +152,15 @@ struct {
 #if MQTT_SUPPORTED == 1
   MqttConfig mqtt;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  String cloud_serial;
+  String cloud_server;
+#endif
   String syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  String auth_user;
+  String auth_pass;
+#endif
   bool force_ap;
 } Config;
 
@@ -210,7 +249,15 @@ void loadConfig() {
   Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user, "");
   Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd, "");
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = prefs.getString(ConfigFiles.cloud_serial, "");
+  Config.cloud_server = prefs.getString(ConfigFiles.cloud_server, "server.growatt.com");
+#endif
   Config.syslog_ip = prefs.getString(ConfigFiles.syslog_ip, "");
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = prefs.getString(ConfigFiles.auth_user, "");
+  Config.auth_pass = prefs.getString(ConfigFiles.auth_pass, "");
+#endif
   Config.force_ap = prefs.getBool(ConfigFiles.force_ap, false);
 }
 
@@ -227,7 +274,15 @@ void saveConfig() {
   prefs.putString(ConfigFiles.mqtt_user, Config.mqtt.user);
   prefs.putString(ConfigFiles.mqtt_pwd, Config.mqtt.pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  prefs.putString(ConfigFiles.cloud_serial, Config.cloud_serial);
+  prefs.putString(ConfigFiles.cloud_server, Config.cloud_server);
+#endif
   prefs.putString(ConfigFiles.syslog_ip, Config.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  prefs.putString(ConfigFiles.auth_user, Config.auth_user);
+  prefs.putString(ConfigFiles.auth_pass, Config.auth_pass);
+#endif
 }
 
 void saveParamCallback() {
@@ -248,7 +303,21 @@ void saveParamCallback() {
   Config.mqtt.user = customWMParams.mqtt_user->getValue();
   Config.mqtt.pwd = customWMParams.mqtt_pwd->getValue();
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = customWMParams.cloud_serial->getValue();
+  Config.cloud_server = customWMParams.cloud_server->getValue();
+  if (Config.cloud_server.isEmpty()) {
+    Config.cloud_server = "server.growatt.com";
+  }
+#endif
   Config.syslog_ip = customWMParams.syslog_ip->getValue();
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = customWMParams.auth_user->getValue();
+  {
+    String val = customWMParams.auth_pass->getValue();
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
 
   saveConfig();
 
@@ -471,11 +540,63 @@ void setup() {
 #ifdef ENABLE_WEB_DEBUG
   httpServer.on("/debug", sendDebug);
 #endif
+  httpServer.on("/config", HTTP_GET, sendConfigJson);
+  httpServer.on("/saveConfig", HTTP_POST, handleSaveConfig);
+  httpServer.on("/cloudStatus", sendCloudStatus);
+  httpServer.on("/systemStatus", sendSystemStatus);
+  httpServer.on("/update", HTTP_GET, sendUpdatePage);
+  httpServer.on("/doUpdate", HTTP_POST, handleUpdateDone, handleUpdateUpload);
   httpServer.onNotFound(handleNotFound);
 
   Inverter.InitProtocol();
   InverterReconnect();
   httpServer.begin();
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Try to auto-read serial from stock firmware's flash area (0x3FD0B4)
+  // This survives OIG flashing since we only write the first ~500KB
+  if (Config.cloud_serial.isEmpty()) {
+    uint8_t flashBuf[12] = {0};
+    char flashSerial[11] = {0};
+    bool found = false;
+#ifdef ESP8266
+    if (ESP.flashRead(0x3FD0B4, (uint32_t*)flashBuf, 12)) {
+      memcpy(flashSerial, flashBuf, 10);
+      flashSerial[10] = '\0';
+      found = true;
+      for (int i = 0; i < 10 && found; i++) {
+        if (flashSerial[i] < 0x20 || flashSerial[i] > 0x7E) {
+          if (i == 0) found = false;
+          else flashSerial[i] = '\0';
+        }
+      }
+    }
+#endif
+    if (found && strlen(flashSerial) >= 6) {
+      Config.cloud_serial = String(flashSerial);
+      saveConfig();
+      Log.print(F("[GrowattCloud] Auto-detected serial from flash: "));
+      Log.println(Config.cloud_serial);
+    }
+  }
+
+  if (!Config.cloud_serial.isEmpty()) {
+    GrowattCloudConfig cloudCfg;
+    strncpy(cloudCfg.serverHost, Config.cloud_server.c_str(), sizeof(cloudCfg.serverHost) - 1);
+    cloudCfg.serverPort = GROWATT_PORT_DEFAULT;
+    cloudCfg.protocolId = GROWATT_PROTO_ENC_V2;
+    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), GROWATT_SERIAL_LEN);
+    memset(cloudCfg.inverterSerial, 0, sizeof(cloudCfg.inverterSerial));
+    strncpy(cloudCfg.fwVersion, "1.7.7.7", sizeof(cloudCfg.fwVersion) - 1);
+    cloudCfg.logIntervalMin = 5;
+    cloudCfg.enabled = true;
+    growattCloud.begin(cloudCfg);
+    Log.println(F("[GrowattCloud] Enabled, serial: "));
+    Log.println(Config.cloud_serial);
+  } else {
+    Log.println(F("[GrowattCloud] Disabled (no serial configured)"));
+  }
+#endif
 
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
 #ifdef ESP32
@@ -524,6 +645,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.mqtt_user);
   wm.addParameter(customWMParams.mqtt_pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  customWMParams.cloud_serial = new WiFiManagerParameter(
+      "cloudsn", "Datalogger Serial (from stick label/AP SSID)",
+      Config.cloud_serial.c_str(), 30);
+  customWMParams.cloud_server = new WiFiManagerParameter(
+      "cloudsrv", "Cloud Server (default: server.growatt.com)",
+      Config.cloud_server.c_str(), 60);
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Growatt Cloud</b> (enter serial to enable, leave blank to disable)</p>"));
+  wm.addParameter(customWMParams.cloud_serial);
+  wm.addParameter(customWMParams.cloud_server);
+#endif
   wm.addParameter(new WiFiManagerParameter(
       "<p><b>Static IP</b> (leave blank for DHCP)</p>"));
   wm.addParameter(customWMParams.static_ip);
@@ -532,6 +665,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.static_dns);
   wm.addParameter(new WiFiManagerParameter("<p><b>Advanced Settings</b></p>"));
   wm.addParameter(customWMParams.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  customWMParams.auth_user = new WiFiManagerParameter(
+      "authuser", "Web UI Username (blank=no auth)",
+      Config.auth_user.c_str(), 30);
+  customWMParams.auth_pass = new WiFiManagerParameter(
+      "authpass", "Web UI Password",
+      "", 30);  // Don't show current password
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Web Authentication</b> (leave blank for open access)</p>"));
+  wm.addParameter(customWMParams.auth_user);
+  wm.addParameter(customWMParams.auth_pass);
+#endif
 
   wm.setSaveParamsCallback(saveParamCallback);
 
@@ -556,6 +701,19 @@ void setupMenu(WiFiManager& wm, bool enableCustomParams) {
   wm.setMenu(menu);  // custom menu, pass vector
 }
 
+bool checkAuth() {
+#if ENABLE_WEB_AUTH == 1
+  if (Config.auth_user.isEmpty() || Config.auth_pass.isEmpty()) {
+    return true;
+  }
+  if (!httpServer.authenticate(Config.auth_user.c_str(), Config.auth_pass.c_str())) {
+    httpServer.requestAuthentication(BASIC_AUTH, "Growatt Inverter");
+    return false;
+  }
+#endif
+  return true;
+}
+
 void sendJson(JsonDocument& doc) {
   httpServer.setContentLength(measureJson(doc));
   httpServer.send(200, "application/json", "");
@@ -565,6 +723,7 @@ void sendJson(JsonDocument& doc) {
 }
 
 void sendJsonSite(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -577,6 +736,7 @@ void sendJsonSite(void) {
 }
 
 void sendUiJsonSite(void) {
+  if (!checkAuth()) return;
   DynamicJsonDocument doc(JSON_DOCUMENT_SIZE);
   Inverter.CreateUIJson(doc, Config.hostname);
 
@@ -584,6 +744,7 @@ void sendUiJsonSite(void) {
 }
 
 void sendMetrics(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -616,6 +777,7 @@ boolean sendMqttJson(void) {
 #endif
 
 void startConfigAccessPoint(void) {
+  if (!checkAuth()) return;
   char msg[384];
 
   snprintf_P(msg, sizeof(msg),
@@ -632,6 +794,7 @@ void startConfigAccessPoint(void) {
 }
 
 void rebootESP(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, F("text/html"),
                   F("<html><body>Rebooting...</body></html>"));
   delay(2000);
@@ -640,19 +803,25 @@ void rebootESP(void) {
 
 #ifdef ENABLE_WEB_DEBUG
 void sendDebug(void) {
+  if (!checkAuth()) return;
   httpServer.sendHeader("Location",
                         "http://" + WiFi.localIP().toString() + ":8080/", true);
   httpServer.send(302, "text/plain", "");
 }
 #endif
 
-void sendMainPage(void) { httpServer.send(200, "text/html", MAIN_page); }
+void sendMainPage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, "text/html", MAIN_page);
+}
 
 void sendPostSite(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, "text/html", SendPostSite_page);
 }
 
 void handlePostData() {
+  if (!checkAuth()) return;
   char msg[256];
   uint16_t u16Tmp;
   uint32_t u32Tmp;
@@ -747,6 +916,176 @@ void handlePostData() {
   }
 }
 
+// -------------------------------------------------------
+// OTA Firmware Update via Web UI
+// -------------------------------------------------------
+void sendUpdatePage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, F("text/html"),
+    F("<!DOCTYPE html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>"
+      "<title>Firmware Update</title>"
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css'>"
+      "</head><body><main class='container'>"
+      "<h2>Firmware Update</h2>"
+      "<form method='POST' action='/doUpdate' enctype='multipart/form-data'>"
+      "<label>Select firmware .bin file:<input type='file' name='update' accept='.bin' required></label>"
+      "<button type='submit'>Upload and Flash</button>"
+      "</form>"
+      "<p><a href='/'>Back to Dashboard</a></p>"
+      "</main></body></html>"));
+}
+
+void handleUpdateUpload(void) {
+  if (!checkAuth()) return;
+  HTTPUpload& upload = httpServer.upload();
+  if (upload.status == UPLOAD_FILE_START) {
+    Log.printf("OTA Update: %s (%u bytes)\n", upload.filename.c_str(), upload.totalSize);
+    uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
+    if (!Update.begin(maxSketchSpace)) {
+      Log.println(F("OTA: Not enough space"));
+    }
+  } else if (upload.status == UPLOAD_FILE_WRITE) {
+    if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
+      Log.println(F("OTA: Write failed"));
+    }
+  } else if (upload.status == UPLOAD_FILE_END) {
+    if (Update.end(true)) {
+      Log.printf("OTA: Success, %u bytes\n", upload.totalSize);
+    } else {
+      Log.println(F("OTA: Failed"));
+    }
+  }
+  yield();
+}
+
+void handleUpdateDone(void) {
+  if (!checkAuth()) return;
+  bool ok = !Update.hasError();
+  httpServer.send(200, F("text/html"),
+    ok ? F("<!DOCTYPE html><html><body><h2>Update Successful!</h2><p>Rebooting...</p></body></html>")
+       : F("<!DOCTYPE html><html><body><h2>Update Failed!</h2><p><a href='/update'>Try again</a></p></body></html>"));
+  if (ok) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendConfigJson(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<512> doc;
+  doc["hostname"] = Config.hostname;
+  doc["static_ip"] = Config.static_ip;
+  doc["static_netmask"] = Config.static_netmask;
+  doc["static_gateway"] = Config.static_gateway;
+  doc["static_dns"] = Config.static_dns;
+#if MQTT_SUPPORTED == 1
+  doc["mqtt_server"] = Config.mqtt.server;
+  doc["mqtt_port"] = Config.mqtt.port;
+  doc["mqtt_topic"] = Config.mqtt.topic;
+  doc["mqtt_user"] = Config.mqtt.user;
+  doc["mqtt_pwd_set"] = !Config.mqtt.pwd.isEmpty();
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloud_serial"] = Config.cloud_serial;
+  doc["cloud_server"] = Config.cloud_server;
+#endif
+  doc["syslog_ip"] = Config.syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  doc["auth_user"] = Config.auth_user;
+  doc["auth_pwd_set"] = !Config.auth_pass.isEmpty();
+#endif
+  sendJson(doc);
+}
+
+void handleSaveConfig(void) {
+  if (!checkAuth()) return;
+  if (httpServer.hasArg(F("hostname"))) Config.hostname = httpServer.arg(F("hostname"));
+  if (httpServer.hasArg(F("static_ip"))) Config.static_ip = httpServer.arg(F("static_ip"));
+  if (httpServer.hasArg(F("static_netmask"))) Config.static_netmask = httpServer.arg(F("static_netmask"));
+  if (httpServer.hasArg(F("static_gateway"))) Config.static_gateway = httpServer.arg(F("static_gateway"));
+  if (httpServer.hasArg(F("static_dns"))) Config.static_dns = httpServer.arg(F("static_dns"));
+#if MQTT_SUPPORTED == 1
+  if (httpServer.hasArg(F("mqtt_server"))) Config.mqtt.server = httpServer.arg(F("mqtt_server"));
+  if (httpServer.hasArg(F("mqtt_port"))) Config.mqtt.port = httpServer.arg(F("mqtt_port"));
+  if (httpServer.hasArg(F("mqtt_topic"))) Config.mqtt.topic = httpServer.arg(F("mqtt_topic"));
+  if (httpServer.hasArg(F("mqtt_user"))) Config.mqtt.user = httpServer.arg(F("mqtt_user"));
+  if (httpServer.hasArg(F("mqtt_pwd"))) {
+    String val = httpServer.arg(F("mqtt_pwd"));
+    if (!val.isEmpty()) Config.mqtt.pwd = val;
+  }
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (httpServer.hasArg(F("cloud_serial"))) Config.cloud_serial = httpServer.arg(F("cloud_serial"));
+  if (httpServer.hasArg(F("cloud_server"))) {
+    String val = httpServer.arg(F("cloud_server"));
+    Config.cloud_server = val.isEmpty() ? "server.growatt.com" : val;
+  }
+#endif
+  if (httpServer.hasArg(F("syslog_ip"))) Config.syslog_ip = httpServer.arg(F("syslog_ip"));
+#if ENABLE_WEB_AUTH == 1
+  if (httpServer.hasArg(F("auth_user"))) Config.auth_user = httpServer.arg(F("auth_user"));
+  if (httpServer.hasArg(F("auth_pass"))) {
+    String val = httpServer.arg(F("auth_pass"));
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
+  saveConfig();
+  bool needRestart = httpServer.hasArg(F("restart"));
+  httpServer.send(200, F("application/json"),
+    needRestart ? F("{\"ok\":true,\"restart\":true}") : F("{\"ok\":true}"));
+  if (needRestart) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendCloudStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<256> doc;
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (!Config.cloud_serial.isEmpty()) {
+    doc["enabled"] = true;
+    const char* stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
+    doc["state"] = stateNames[growattCloud.getState()];
+    doc["stateCode"] = (int)growattCloud.getState();
+    doc["packetsSent"] = growattCloud.getPacketsSent();
+    doc["packetsRecv"] = growattCloud.getPacketsRecv();
+    doc["reconnects"] = growattCloud.getReconnects();
+    uint32_t lastSend = growattCloud.getLastSendTime();
+    doc["lastSendAgo"] = lastSend > 0 ? (int)((millis() - lastSend) / 1000) : -1;
+    doc["serial"] = Config.cloud_serial;
+    doc["server"] = Config.cloud_server;
+  } else {
+    doc["enabled"] = false;
+  }
+#else
+  doc["supported"] = false;
+#endif
+  sendJson(doc);
+}
+
+void sendSystemStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<384> doc;
+  doc["hostname"] = Config.hostname;
+  doc["ip"] = WiFi.localIP().toString();
+  doc["gateway"] = WiFi.gatewayIP().toString();
+  doc["netmask"] = WiFi.subnetMask().toString();
+  doc["dns"] = WiFi.dnsIP().toString();
+  doc["ssid"] = WiFi.SSID();
+  doc["rssi"] = WiFi.RSSI();
+  doc["heap"] = ESP.getFreeHeap();
+  doc["uptime"] = millis() / 1000;
+  doc["mac"] = WiFi.macAddress();
+  doc["stickType"] = Inverter.GetWiFiStickType() == ShineWiFi_S ? "ShineWiFi-S" :
+                     Inverter.GetWiFiStickType() == ShineWiFi_X ? "ShineWiFi-X" : "Unknown";
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloudSerial"] = Config.cloud_serial;
+  doc["cloudState"] = growattCloud.isConnected() ? "Active" : "Disconnected";
+#endif
+  sendJson(doc);
+}
+
 bool sendSingleValue(void) {
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
@@ -762,6 +1101,7 @@ bool sendSingleValue(void) {
 }
 
 void handleNotFound() {
+  if (!checkAuth()) return;
   if (httpServer.uri().startsWith(F("/value/")) &&
       httpServer.uri().length() > 7) {
     if (sendSingleValue()) {
@@ -896,6 +1236,24 @@ void loop() {
 #endif
           handleWdtReset(mqttSuccess);
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+          // Feed register data to Growatt Cloud sender
+          if (!Config.cloud_serial.isEmpty()) {
+            // Build arrays of raw register values for cloud protocol
+            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
+            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            uint16_t inputRegs[125];
+            uint16_t holdingRegs[35];
+            for (uint16_t i = 0; i < numInput && i < 125; i++) {
+              inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
+            }
+            for (uint16_t i = 0; i < numHolding && i < 35; i++) {
+              holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
+            }
+            growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);
+          }
+#endif
+
           // leave while-loop
           readoutSucceeded = true;
         } else {
@@ -943,6 +1301,13 @@ void loop() {
 
     RefreshTimer = now;
   }
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Keep Growatt Cloud connection alive (pings, server responses)
+  if (!Config.cloud_serial.isEmpty()) {
+    growattCloud.loop(nullptr, 0);
+  }
+#endif
 
 #if OTA_SUPPORTED == 1
   // check for OTA updates

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -1138,14 +1138,18 @@ void handleSetParam(void) {
     ok = wroteMode && wrotePf;
     snprintf(msg, sizeof(msg), "HR 99 = 1, HR 5 = %u (PF=%.2f) : %s",
              scaled, pf, ok ? "OK" : "Modbus write failed");
-  } else if (type == "pv_grid_voltage_high") {
-    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
-    uint16_t raw = (uint16_t)(v1.toFloat() * 10.0f);  // /10 multiplier per Growatt convention
-    ok = write1(23, raw, msg, sizeof(msg));
-  } else if (type == "pv_grid_voltage_low") {
-    if (v1.length() == 0) { httpServer.send(400, F("text/plain"), F("voltage required")); return; }
-    uint16_t raw = (uint16_t)(v1.toFloat() * 10.0f);
-    ok = write1(24, raw, msg, sizeof(msg));
+  } else if (type == "pv_grid_voltage_high" || type == "pv_grid_voltage_low") {
+    // Holding regs 23-27 are the inverter serial (ASCII), NOT voltage limits.
+    // The cloud's real `pv_grid_voltage_high/low` register addresses haven't
+    // been captured yet (we intentionally skipped exercising them since
+    // wrong values can take the inverter offline). Refuse for safety until
+    // a real cloud-side WRITE_REG is observed and recorded here.
+    httpServer.send(503, F("text/plain"),
+        F("Voltage limit registers not verified yet. Trigger this command "
+          "from the Shine cloud portal once so the firmware can capture the "
+          "real register address (visible as a [GrowattCloud] WRITE_REG line "
+          "in syslog), then update handleSetParam to use it."));
+    return;
   } else if (type == "pf_sys_year") {
     time_t now = time(nullptr);
     struct tm* lt = localtime(&now);


### PR DESCRIPTION
## Summary

Modernizes the web interface with a clean tabbed layout.

- **Pico CSS** from CDN with inline fallback (no flash cost for CSS)
- **5 tabs**: Dashboard (existing charts preserved), Config, Cloud Status, Debug Log, System
- **Config in normal mode**: change MQTT/network/auth settings without AP mode restart
- **HTTP Basic Auth**: optional, configurable via Config tab or WiFiManager portal
- **System info**: gateway, netmask, DNS, SSID, WiFi signal, free heap
- **HTTP firmware update** (`/update`): upload .bin files without serial adapter
- **Embedded debug log**: iframe to WebSerialStream (no port 8080 redirect)

## New Config.h options
- `GROWATT_CLOUD_SUPPORTED` - enables cloud config fields (actual protocol in separate PR)
- `ENABLE_WEB_AUTH` - enables HTTP Basic Auth

## Test plan
- [x] Dashboard tab preserves existing Chart.js and uiStatus polling
- [x] Config tab loads/saves settings via /config and /saveConfig
- [x] Auth: set user/pass, browser prompts; clear both, open access restored
- [x] System tab shows network info including DHCP-assigned gateway/DNS
- [x] /update endpoint accepts firmware uploads
- [x] CDN offline: page still usable with fallback CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)