### PR TITLE
feat: extend Growatt v3.05 input register map (12 -> 34 fields)

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -22,6 +22,18 @@
 // Setting this define to 0 will disable the MQTT functionality
 #define MQTT_SUPPORTED 1
 
+// Setting this define to 1 enables Growatt Cloud forwarding.
+// Sends inverter data to server.growatt.com:5279 so ShinePhone app
+// and Growatt web portal continue working alongside local MQTT.
+// The datalogger serial is auto-detected from the stock firmware's
+// flash area, or can be entered in the GrowattConfig portal.
+#define GROWATT_CLOUD_SUPPORTED 1
+
+// Setting this define to 1 enables HTTP Basic Auth for the web UI.
+// Auth credentials are configured via the GrowattConfig portal or web UI.
+// If no credentials are set, the UI is open (backward compatible).
+#define ENABLE_WEB_AUTH 1
+
 // Enable OTA update via espota. This is mainly for development purposes and enables updates
 // of the device without physical access. Use at our own risk!
 #define OTA_SUPPORTED 0

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -27,7 +27,11 @@
 // and Growatt web portal continue working alongside local MQTT.
 // The datalogger serial is auto-detected from the stock firmware's
 // flash area, or can be entered in the GrowattConfig portal.
-#define GROWATT_CLOUD_SUPPORTED 1
+//
+// NOTE: enabling this requires GrowattCloud.{h,cpp} to be present.
+// Those files are introduced in a separate PR; until that PR is merged,
+// keep this flag at 0 to build the rest of the changes standalone.
+#define GROWATT_CLOUD_SUPPORTED 0
 
 // Setting this define to 1 enables HTTP Basic Auth for the web UI.
 // Auth credentials are configured via the GrowattConfig portal or web UI.

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -300,6 +300,24 @@ bool Growatt::ReadHoldingReg(uint16_t adr, uint32_t* result) {
 #endif
 }
 
+bool Growatt::ReadInputRegFrag(uint16_t adr, uint8_t size, uint16_t* result) {
+  /**
+   * @brief read 16b input register fragment via FC04
+   * @param adr Modbus wire start address
+   * @param size number of registers to read
+   * @param result pointer to buffer (must hold `size` uint16 values)
+   * @returns true if successful
+   */
+  uint8_t res = Modbus.readInputRegisters(adr, size);
+  if (res == Modbus.ku8MBSuccess) {
+    for (int i = 0; i < size; i++) {
+      result[i] = Modbus.getResponseBuffer(i);
+    }
+    return true;
+  }
+  return false;
+}
+
 bool Growatt::ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* result) {
   /**
    * @brief read 16b holding register fragment

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -24,6 +24,7 @@ class Growatt {
   sGrowattModbusReg_t GetHoldingRegister(uint16_t reg);
   bool ReadInputReg(uint16_t adr, uint32_t* result);
   bool ReadInputReg(uint16_t adr, uint16_t* result);
+  bool ReadInputRegFrag(uint16_t adr, uint8_t size, uint16_t* result);
   bool ReadHoldingReg(uint16_t adr, uint32_t* result);
   bool ReadHoldingReg(uint16_t adr, uint16_t* result);
   bool ReadHoldingRegFrag(uint16_t adr, uint8_t size, uint16_t* result);

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -4,44 +4,88 @@
 #include "Growatt305.h"
 
 void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter) {
-  // definition of input registers
-  Protocol.InputRegisterCount = 12;
-  // address, value, size, name, multiplier, unit, frontend, plot
-  // FRAGMENT 1: BEGIN
+  // Input register map for Growatt v3.05 protocol, block 1 (regs 0-44).
+  // Block 2 (47-89) is fetched separately by the .ino because this inverter's
+  // FC04 response to start=45 returns data shifted by +2 (see ShineWiFi-ModBus
+  // .ino cloud-feed section).
+  //
+  // address, value, size, name, multiplier, resolution, unit, frontend, plot
+  // Entries MUST stay sorted by address (Growatt::ReadInputRegisters j-walk).
+
+  Protocol.InputRegisterCount = 34;
+
   Protocol.InputRegisters[P305_I_STATUS] = sGrowattModbusReg_t{
-      0, 0, SIZE_16BIT, F("InverterStatus"), 1, 1, NONE, true, false};  // #1
+      0, 0, SIZE_16BIT, F("InverterStatus"), 1, 1, NONE, true, false};
   Protocol.InputRegisters[P305_DC_POWER] = sGrowattModbusReg_t{
-      1, 0, SIZE_32BIT, F("DcPower"), 0.1, 0.1, POWER_W, true, true};  // #2
+      1, 0, SIZE_32BIT, F("DcPower"), 0.1, 0.1, POWER_W, true, true};
   Protocol.InputRegisters[P305_DC_VOLTAGE] = sGrowattModbusReg_t{
-      3, 0, SIZE_16BIT, F("DcVoltage"), 0.1, 0.1, VOLTAGE, true, false};  // #3
+      3, 0, SIZE_16BIT, F("DcVoltage"), 0.1, 0.1, VOLTAGE, true, false};
   Protocol.InputRegisters[P305_DC_INPUT_CURRENT] = sGrowattModbusReg_t{
-      4,       0,    SIZE_16BIT, F("DcInputCurrent"), 0.1, 0.1,
-      CURRENT, true, false};  // #4
+      4, 0, SIZE_16BIT, F("DcInputCurrent"), 0.1, 0.1, CURRENT, true, false};
+  Protocol.InputRegisters[P305_PV1_POWER] = sGrowattModbusReg_t{
+      5, 0, SIZE_32BIT, F("Pv1Power"), 0.1, 0.1, POWER_W, true, false};
+  Protocol.InputRegisters[P305_PV2_VOLTAGE] = sGrowattModbusReg_t{
+      7, 0, SIZE_16BIT, F("Pv2Voltage"), 0.1, 0.1, VOLTAGE, true, false};
+  Protocol.InputRegisters[P305_PV2_CURRENT] = sGrowattModbusReg_t{
+      8, 0, SIZE_16BIT, F("Pv2Current"), 0.1, 0.1, CURRENT, true, false};
+  Protocol.InputRegisters[P305_PV2_POWER] = sGrowattModbusReg_t{
+      9, 0, SIZE_32BIT, F("Pv2Power"), 0.1, 0.1, POWER_W, true, false};
+  Protocol.InputRegisters[P305_PAC_TOTAL] = sGrowattModbusReg_t{
+      11, 0, SIZE_32BIT, F("PacTotal"), 0.1, 0.1, POWER_W, true, true};
   Protocol.InputRegisters[P305_AC_FREQUENCY] = sGrowattModbusReg_t{
-      13,        0,    SIZE_16BIT, F("AcFrequency"), 0.01, 0.01,
-      FREQUENCY, true, false};  // #5
+      13, 0, SIZE_16BIT, F("AcFrequency"), 0.01, 0.01, FREQUENCY, true, false};
   Protocol.InputRegisters[P305_AC_VOLTAGE] = sGrowattModbusReg_t{
-      14, 0, SIZE_16BIT, F("AcVoltage"), 0.1, 0.1, VOLTAGE, true, false};  // #6
+      14, 0, SIZE_16BIT, F("AcVoltage"), 0.1, 0.1, VOLTAGE, true, false};
   Protocol.InputRegisters[P305_AC_OUTPUT_CURRENT] = sGrowattModbusReg_t{
-      15,      0,    SIZE_16BIT, F("AcOutputCurrent"), 0.1, 0.1,
-      CURRENT, true, false};  // #7
+      15, 0, SIZE_16BIT, F("AcOutputCurrent"), 0.1, 0.1, CURRENT, true, false};
   Protocol.InputRegisters[P305_AC_POWER] = sGrowattModbusReg_t{
-      16, 0, SIZE_32BIT, F("AcPower"), 0.1, 0.1, POWER_W, true, true};  // #8
+      16, 0, SIZE_32BIT, F("AcPower"), 0.1, 0.1, POWER_W, true, true};
+  Protocol.InputRegisters[P305_AC_VOLTAGE_L2] = sGrowattModbusReg_t{
+      18, 0, SIZE_16BIT, F("AcVoltageL2"), 0.1, 0.1, VOLTAGE, true, false};
+  Protocol.InputRegisters[P305_AC_CURRENT_L2] = sGrowattModbusReg_t{
+      19, 0, SIZE_16BIT, F("AcCurrentL2"), 0.1, 0.1, CURRENT, true, false};
+  Protocol.InputRegisters[P305_AC_POWER_L2] = sGrowattModbusReg_t{
+      20, 0, SIZE_32BIT, F("AcPowerL2"), 0.1, 0.1, POWER_W, true, false};
+  Protocol.InputRegisters[P305_AC_VOLTAGE_L3] = sGrowattModbusReg_t{
+      22, 0, SIZE_16BIT, F("AcVoltageL3"), 0.1, 0.1, VOLTAGE, true, false};
+  Protocol.InputRegisters[P305_AC_CURRENT_L3] = sGrowattModbusReg_t{
+      23, 0, SIZE_16BIT, F("AcCurrentL3"), 0.1, 0.1, CURRENT, true, false};
+  Protocol.InputRegisters[P305_AC_POWER_L3] = sGrowattModbusReg_t{
+      24, 0, SIZE_32BIT, F("AcPowerL3"), 0.1, 0.1, POWER_W, true, false};
   Protocol.InputRegisters[P305_ENERGY_TODAY] = sGrowattModbusReg_t{
-      26,        0,    SIZE_32BIT, F("EnergyToday"), 0.1, 0.1,
-      POWER_KWH, true, false};  // #9
+      26, 0, SIZE_32BIT, F("EnergyToday"), 0.1, 0.1, POWER_KWH, true, false};
   Protocol.InputRegisters[P305_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      28,        0,    SIZE_32BIT, F("EnergyTotal"), 0.1, 0.1,
-      POWER_KWH, true, false};  // #10
-  Protocol.InputRegisters[P305_OPERATING_TIME] =
-      sGrowattModbusReg_t{30,      0,    SIZE_32BIT, F("OperatingTime"), 0.5, 1,
-                          SECONDS, true, false};  // #11
+      28, 0, SIZE_32BIT, F("EnergyTotal"), 0.1, 0.1, POWER_KWH, true, false};
+  Protocol.InputRegisters[P305_OPERATING_TIME] = sGrowattModbusReg_t{
+      30, 0, SIZE_32BIT, F("OperatingTime"), 0.5, 1, SECONDS, true, false};
   Protocol.InputRegisters[P305_TEMPERATURE] = sGrowattModbusReg_t{
-      32,          0,    SIZE_16BIT, F("Temperature"), 0.1, 0.1,
-      TEMPERATURE, true, false};  // #12
+      32, 0, SIZE_16BIT, F("Temperature"), 0.1, 0.1, TEMPERATURE, true, false};
+  Protocol.InputRegisters[P305_ISO_FAULT] = sGrowattModbusReg_t{
+      33, 0, SIZE_16BIT, F("IsoFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_GFCI_FAULT] = sGrowattModbusReg_t{
+      34, 0, SIZE_16BIT, F("GfciFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_DCI_FAULT] = sGrowattModbusReg_t{
+      35, 0, SIZE_16BIT, F("DciFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_VPV_FAULT] = sGrowattModbusReg_t{
+      36, 0, SIZE_16BIT, F("VpvFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_VAC_FAULT] = sGrowattModbusReg_t{
+      37, 0, SIZE_16BIT, F("VacFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_FAC_FAULT] = sGrowattModbusReg_t{
+      38, 0, SIZE_16BIT, F("FacFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_TMP_FAULT] = sGrowattModbusReg_t{
+      39, 0, SIZE_16BIT, F("TmpFault"), 1, 1, NONE, false, false};
+  Protocol.InputRegisters[P305_FAULT_CODE] = sGrowattModbusReg_t{
+      40, 0, SIZE_16BIT, F("FaultCode"), 1, 1, NONE, true, false};
+  Protocol.InputRegisters[P305_IPM_TEMPERATURE] = sGrowattModbusReg_t{
+      41,          0,    SIZE_16BIT, F("IpmTemperature"), 0.1, 0.1,
+      TEMPERATURE, true, false};
+  Protocol.InputRegisters[P305_PBUS_VOLTAGE] = sGrowattModbusReg_t{
+      42, 0, SIZE_16BIT, F("PBusVoltage"), 0.1, 0.1, VOLTAGE, false, false};
+  Protocol.InputRegisters[P305_NBUS_VOLTAGE] = sGrowattModbusReg_t{
+      43, 0, SIZE_16BIT, F("NBusVoltage"), 0.1, 0.1, VOLTAGE, false, false};
 
   Protocol.InputFragmentCount = 1;
-  Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 33};
+  Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 45};
 
   Protocol.HoldingRegisterCount = 0;
   Protocol.HoldingFragmentCount = 0;

--- a/SRC/ShineWiFi-ModBus/Growatt305.h
+++ b/SRC/ShineWiFi-ModBus/Growatt305.h
@@ -5,19 +5,46 @@
 #include "GrowattTypes.h"
 
 // Growatt MODBUS protocol V3.05 (2013-04-25)
+// Input register indices into Protocol.InputRegisters[]. Must remain sorted
+// by Modbus address (see Growatt::ReadInputRegisters j-walk).
+// Only block 1 (regs 0-44) is mapped here. Block 2 (47-89) is read raw from
+// the .ino for the cloud sender because this inverter's FC04 response shifts
+// block-2 data by +2 registers, which the standard fragment math can't model.
 typedef enum {
-  P305_I_STATUS = 0,
-  P305_DC_POWER,
-  P305_DC_VOLTAGE,
-  P305_DC_INPUT_CURRENT,
-  P305_AC_FREQUENCY,
-  P305_AC_VOLTAGE,
-  P305_AC_OUTPUT_CURRENT,
-  P305_AC_POWER,
-  P305_ENERGY_TODAY,
-  P305_ENERGY_TOTAL,
-  P305_OPERATING_TIME,
-  P305_TEMPERATURE,
+  P305_I_STATUS = 0,       // R0
+  P305_DC_POWER,           // R1-2  (Ppv total, U32)
+  P305_DC_VOLTAGE,         // R3
+  P305_DC_INPUT_CURRENT,   // R4
+  P305_PV1_POWER,          // R5-6  (U32)
+  P305_PV2_VOLTAGE,        // R7
+  P305_PV2_CURRENT,        // R8
+  P305_PV2_POWER,          // R9-10 (U32)
+  P305_PAC_TOTAL,          // R11-12 (total AC output power, U32)
+  P305_AC_FREQUENCY,       // R13
+  P305_AC_VOLTAGE,         // R14  (L1)
+  P305_AC_OUTPUT_CURRENT,  // R15  (L1)
+  P305_AC_POWER,           // R16-17 (Pac L1, U32 - keeps legacy name)
+  P305_AC_VOLTAGE_L2,      // R18
+  P305_AC_CURRENT_L2,      // R19
+  P305_AC_POWER_L2,        // R20-21 (U32)
+  P305_AC_VOLTAGE_L3,      // R22
+  P305_AC_CURRENT_L3,      // R23
+  P305_AC_POWER_L3,        // R24-25 (U32)
+  P305_ENERGY_TODAY,       // R26-27 (U32)
+  P305_ENERGY_TOTAL,       // R28-29 (U32)
+  P305_OPERATING_TIME,     // R30-31 (U32)
+  P305_TEMPERATURE,        // R32
+  P305_ISO_FAULT,          // R33
+  P305_GFCI_FAULT,         // R34
+  P305_DCI_FAULT,          // R35
+  P305_VPV_FAULT,          // R36
+  P305_VAC_FAULT,          // R37
+  P305_FAC_FAULT,          // R38
+  P305_TMP_FAULT,          // R39
+  P305_FAULT_CODE,         // R40
+  P305_IPM_TEMPERATURE,    // R41
+  P305_PBUS_VOLTAGE,       // R42
+  P305_NBUS_VOLTAGE,       // R43
 } eP305InputRegisters_t;
 
 void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter);

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -1,209 +1,352 @@
 #pragma once
 
-const char MAIN_page[] PROGMEM = R"=====(
+const char MAIN_page[] PROGMEM = R"rawliteral(
 <!DOCTYPE HTML>
-<html lang="en">
-
-<!-- Rui Santos - Complete project details at https://RandomNerdTutorials.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files.
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software. -->
-
+<html lang="en" data-theme="light">
 <head>
-    <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Growatt Inverter</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js" integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-
-    <style>
-        body {
-            min-width: 310px;
-            max-width: 800px;
-            height: 400px;
-            margin: 0 auto;
-            font-family: Arial;
-        }
-
-        h2 {
-            font-size: 2.5rem;
-            text-align: center;
-        }
-
-        div {
-            font-size: 1rem;
-            padding: 10px 0px 10px 0px;
-        }
-
-        .linkButtonBar {
-            text-align: center;
-            padding: 20px 0px 20px 0px;
-        }
-
-        .linkButton {
-            -webkit-border-radius: 4px;
-            -moz-border-radius: 4px;
-            border-radius: 4px;
-            border: solid 1px #91ca5f;
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background: #6eb92b;
-            color: #FFF;
-            padding: 8px 12px;
-            text-decoration: none;
-            display: inline-block;
-            margin: 2px;
-            font-size: .8rem;
-            text-align: center;
-        }
-
-        .yellow {
-            border: solid 1px rgb(202, 189, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 178, 43);
-        }
-
-        .red {
-            border: solid 1px rgb(202, 95, 95);
-            text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-            -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            -moz-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
-            background:rgb(185, 43, 43);
-        }
-    </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Growatt Inverter</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
+  onerror="document.body.classList.add('no-cdn')">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js"
+  integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw=="
+  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<style>
+  /* Tab bar */
+  .tabs{display:flex;gap:0;border-bottom:2px solid #ccc;margin-bottom:1rem}
+  .tabs button{background:none;border:none;padding:.6rem 1.2rem;cursor:pointer;
+    font-size:.95rem;border-bottom:3px solid transparent;color:#555}
+  .tabs button.active{border-bottom-color:#1a73e8;color:#1a73e8;font-weight:600}
+  .tabs button:hover{color:#1a73e8}
+  .tab-content{display:none}
+  .tab-content.active{display:block}
+  /* Status badges */
+  .badge{display:inline-block;padding:.15em .5em;border-radius:4px;font-size:.85rem;font-weight:600;color:#fff}
+  .badge-ok{background:#2e7d32}
+  .badge-warn{background:#ed6c02}
+  .badge-err{background:#d32f2f}
+  .badge-off{background:#757575}
+  /* Config form */
+  .cfg-msg{padding:.5rem;border-radius:4px;margin-bottom:.5rem;display:none}
+  .cfg-msg.ok{display:block;background:#e8f5e9;color:#2e7d32}
+  .cfg-msg.err{display:block;background:#ffebee;color:#c62828}
+  /* Debug iframe */
+  .debug-frame{width:100%;height:500px;border:1px solid #ccc;border-radius:4px}
+  /* Fallback CSS when CDN is offline */
+  .no-cdn{font-family:system-ui,-apple-system,sans-serif;max-width:900px;margin:0 auto;padding:1rem}
+  .no-cdn h1{font-size:1.6rem}
+  .no-cdn table{width:100%;border-collapse:collapse;margin:.5rem 0}
+  .no-cdn th,.no-cdn td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid #ddd}
+  .no-cdn input,.no-cdn select{padding:.3rem .5rem;border:1px solid #aaa;border-radius:3px;width:100%;box-sizing:border-box}
+  .no-cdn button[type=submit]{background:#1a73e8;color:#fff;border:none;padding:.5rem 1.5rem;border-radius:4px;cursor:pointer}
+  .no-cdn details{border:1px solid #ddd;border-radius:4px;padding:.5rem;margin:.5rem 0}
+  .no-cdn summary{cursor:pointer;font-weight:600}
+</style>
 </head>
-
 <body>
-    <h2>Growatt Inverter</h2>
+<main class="container">
+<h1>Growatt Inverter</h1>
 
-    <div><canvas id="powerChart"></canvas></div>
+<nav class="tabs">
+  <button class="active" data-tab="dash">Dashboard</button>
+  <button data-tab="cfg">Config</button>
+  <button data-tab="cloud">Cloud</button>
+  <button data-tab="dbg">Debug Log</button>
+  <button data-tab="sys">System</button>
+</nav>
 
-    <div class="linkButtonBar">
-        <a href="./status" class="linkButton">Json</a>
-        <a href="./uiStatus" class="linkButton">UI Json</a>
-        <a href="./metrics" class="linkButton">Metrics</a>
-        <a href="./debug" class="linkButton">Log</a>
-        <a onClick="return confirm('Starting config AP will disconnect you from the device. Are you sure?');" href="./startAp" class="linkButton yellow">Start Config AP</a>
-        <a onClick="return confirm('This will reboot the Wifi Stick. Are you sure?');" href="./reboot" class="linkButton yellow">Reboot</a>
-        <a href="./postCommunicationModbus" class="linkButton red">RW Modbus</a>
-    </div>
+<!-- ===== Dashboard Tab ===== -->
+<section id="tab-dash" class="tab-content active">
+  <div><canvas id="powerChart"></canvas></div>
+  <div id="DataContainer"></div>
+</section>
 
-    <div id="DataContainer"></div>
+<!-- ===== Config Tab ===== -->
+<section id="tab-cfg" class="tab-content">
+  <div id="cfgMsg" class="cfg-msg"></div>
+  <form id="cfgForm">
+    <details open>
+      <summary>Network</summary>
+      <label>Hostname <input name="hostname" id="c_hostname"></label>
+      <label>Static IP <input name="static_ip" id="c_static_ip" placeholder="leave blank for DHCP"></label>
+      <label>Netmask <input name="static_netmask" id="c_static_netmask"></label>
+      <label>Gateway <input name="static_gateway" id="c_static_gateway"></label>
+      <label>DNS <input name="static_dns" id="c_static_dns"></label>
+    </details>
+    <details>
+      <summary>MQTT</summary>
+      <label>Server <input name="mqtt_server" id="c_mqtt_server" placeholder="leave blank to disable"></label>
+      <label>Port <input name="mqtt_port" id="c_mqtt_port"></label>
+      <label>Topic <input name="mqtt_topic" id="c_mqtt_topic"></label>
+      <label>Username <input name="mqtt_user" id="c_mqtt_user"></label>
+      <label>Password <input name="mqtt_pwd" type="password" id="c_mqtt_pwd" placeholder="unchanged if blank"></label>
+      <small id="c_mqtt_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Growatt Cloud</summary>
+      <label>Datalogger Serial <input name="cloud_serial" id="c_cloud_serial" placeholder="from stick label"></label>
+      <label>Server <input name="cloud_server" id="c_cloud_server" placeholder="server.growatt.com"></label>
+    </details>
+    <details>
+      <summary>Authentication</summary>
+      <label>Username <input name="auth_user" id="c_auth_user" placeholder="blank = no auth"></label>
+      <label>Password <input name="auth_pass" type="password" id="c_auth_pass" placeholder="unchanged if blank"></label>
+      <small id="c_auth_pwd_hint"></small>
+    </details>
+    <details>
+      <summary>Advanced</summary>
+      <label>Syslog IP <input name="syslog_ip" id="c_syslog_ip" placeholder="leave blank for none"></label>
+    </details>
+    <label><input type="checkbox" name="restart" value="1"> Restart after saving</label>
+    <button type="submit">Save Configuration</button>
+  </form>
+</section>
+
+<!-- ===== Cloud Tab ===== -->
+<section id="tab-cloud" class="tab-content">
+  <table id="cloudTable" role="grid">
+    <tbody>
+      <tr><th>Status</th><td id="cl_state">--</td></tr>
+      <tr><th>Serial</th><td id="cl_serial">--</td></tr>
+      <tr><th>Server</th><td id="cl_server">--</td></tr>
+      <tr><th>Packets Sent</th><td id="cl_sent">--</td></tr>
+      <tr><th>Packets Received</th><td id="cl_recv">--</td></tr>
+      <tr><th>Reconnects</th><td id="cl_recon">--</td></tr>
+      <tr><th>Last Send</th><td id="cl_last">--</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ===== Debug Log Tab ===== -->
+<section id="tab-dbg" class="tab-content">
+  <p>WebSerial debug stream (port 8080):</p>
+  <iframe id="debugFrame" class="debug-frame"></iframe>
+</section>
+
+<!-- ===== System Tab ===== -->
+<section id="tab-sys" class="tab-content">
+  <table id="sysTable" role="grid">
+    <tbody>
+      <tr><th>Hostname</th><td id="s_host">--</td></tr>
+      <tr><th>IP Address</th><td id="s_ip">--</td></tr>
+      <tr><th>Gateway</th><td id="s_gw">--</td></tr>
+      <tr><th>Netmask</th><td id="s_mask">--</td></tr>
+      <tr><th>DNS</th><td id="s_dns">--</td></tr>
+      <tr><th>WiFi SSID</th><td id="s_ssid">--</td></tr>
+      <tr><th>WiFi RSSI</th><td id="s_rssi">--</td></tr>
+      <tr><th>MAC Address</th><td id="s_mac">--</td></tr>
+      <tr><th>Free Heap</th><td id="s_heap">--</td></tr>
+      <tr><th>Uptime</th><td id="s_up">--</td></tr>
+      <tr><th>Stick Type</th><td id="s_stick">--</td></tr>
+    </tbody>
+  </table>
+  <h4>Quick Links</h4>
+  <p>
+    <a href="./status" role="button" class="outline">JSON</a>
+    <a href="./uiStatus" role="button" class="outline">UI JSON</a>
+    <a href="./metrics" role="button" class="outline">Prometheus</a>
+    <a href="./postCommunicationModbus" role="button" class="outline secondary">RW Modbus</a>
+  </p>
+  <h4>Maintenance</h4>
+  <p>
+    <a href="./update" role="button" class="outline">Firmware Update</a>
+    <a href="#" role="button" class="outline contrast" id="btnAp"
+       onclick="if(confirm('Starting config AP will disconnect you. Continue?'))location='./startAp';return false;">Start Config AP</a>
+    <a href="#" role="button" class="outline contrast" id="btnReboot"
+       onclick="if(confirm('Reboot the WiFi stick?'))location='./reboot';return false;">Reboot</a>
+  </p>
+</section>
 
 <script>
-    let initialised = false;
-    const powerchartelement = document.getElementById('powerChart');
-
-    const CHART_COLORS = {
-        red: 'rgb(255, 99, 132)',
-        orange: 'rgb(255, 159, 64)',
-        yellow: 'rgb(255, 205, 86)',
-        green: 'rgb(75, 192, 192)',
-        blue: 'rgb(54, 162, 235)',
-        purple: 'rgb(153, 102, 255)',
-        grey: 'rgb(201, 203, 207)'
-    };
-
-    const NAMED_COLORS = [
-        CHART_COLORS.red,
-        CHART_COLORS.orange,
-        CHART_COLORS.yellow,
-        CHART_COLORS.green,
-        CHART_COLORS.blue,
-        CHART_COLORS.purple,
-        CHART_COLORS.grey,
-    ];
-
-    function namedColor(index) {
-        return NAMED_COLORS[index % NAMED_COLORS.length];
+/* ---- Tab switching ---- */
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    document.querySelectorAll('.tabs button').forEach(function(b){b.classList.remove('active')});
+    document.querySelectorAll('.tab-content').forEach(function(t){t.classList.remove('active')});
+    btn.classList.add('active');
+    var target = document.getElementById('tab-' + btn.getAttribute('data-tab'));
+    target.classList.add('active');
+    /* Lazy-load debug iframe */
+    if(btn.getAttribute('data-tab')==='dbg'){
+      var fr = document.getElementById('debugFrame');
+      if(!fr.src || fr.src===''){
+        fr.src = 'http://' + location.hostname + ':8080/';
+      }
     }
+    /* Fetch config when switching to config tab */
+    if(btn.getAttribute('data-tab')==='cfg') loadConfig();
+    /* Fetch system status */
+    if(btn.getAttribute('data-tab')==='sys') fetchSystem();
+  });
+});
 
-    const powerchartData = {
-        labels: [],
-        datasets: [],
-    };
-
-    let powerchart = new Chart(powerchartelement, {
-        type: 'line',
-        data: powerchartData,
-        options: {
-            scales: {
-                y: {
-                    beginAtZero: true
-                }
-            }
+/* ---- Dashboard: Chart.js + uiStatus polling (preserved from original) ---- */
+var initialised = false;
+var powerchartelement = document.getElementById('powerChart');
+var CHART_COLORS = {
+  red:'rgb(255,99,132)', orange:'rgb(255,159,64)', yellow:'rgb(255,205,86)',
+  green:'rgb(75,192,192)', blue:'rgb(54,162,235)', purple:'rgb(153,102,255)', grey:'rgb(201,203,207)'
+};
+var NAMED_COLORS = [CHART_COLORS.red, CHART_COLORS.orange, CHART_COLORS.yellow,
+  CHART_COLORS.green, CHART_COLORS.blue, CHART_COLORS.purple, CHART_COLORS.grey];
+function namedColor(i){return NAMED_COLORS[i % NAMED_COLORS.length]}
+var powerchartData = {labels:[], datasets:[]};
+var powerchart = new Chart(powerchartelement, {
+  type:'line', data:powerchartData,
+  options:{scales:{y:{beginAtZero:true}}}
+});
+setInterval(function(){
+  var xhttp = new XMLHttpRequest();
+  xhttp.onreadystatechange = function(){
+    if(this.readyState==4 && this.status==200){
+      var obj = JSON.parse(this.responseText);
+      var date = new Date();
+      powerchartData.labels.push(date.getHours()+":"+date.getMinutes()+":"+date.getSeconds());
+      if(initialised==false){
+        initialised = true;
+        var container = document.getElementById("DataContainer");
+        container.innerHTML = "";
+        for(var key in obj){
+          if(obj[key][2]==true){
+            var nd = {label:key, data:[obj[key][0]], fill:false,
+              borderColor:namedColor(powerchart.data.datasets.length), tension:0.1};
+            powerchartData.datasets.push(nd);
+            powerchart.update();
+          }
+          var el = document.createElement("p");
+          el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          el.setAttribute("id", key);
+          container.appendChild(el);
         }
-    });
-
-    setInterval(function () {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function () {
-            if (this.readyState == 4 && this.status == 200) {
-                // add data fields to the main page
-                var obj = JSON.parse(this.responseText);
-                // Add Date to chart x Axis
-                let date = new Date();
-                powerchartData.labels.push(date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds());
-                if (initialised == false) {
-                    initialised = true;
-                    // clear data view container just in case
-                    container = document.getElementById("DataContainer");
-                    container.innerHTML = "";
-                    // Add Data Labels to chart
-                    for (var key in obj) {
-                        if (obj[key][2] == true) {
-                            const newDataset = {
-                                label: key,
-                                data: [obj[key][0]],
-                                fill: false,
-                                borderColor: namedColor(powerchart.data.datasets.length),
-                                tension: 0.1
-                            };
-                            powerchartData.datasets.push(newDataset);
-                            powerchart.update();
-                        }
-                        // init dataview
-                        var element = document.createElement("p");
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        element.setAttribute("id", key);
-                        container.appendChild(element);
-                    }
-                } else {
-                    // Update Data in chart
-                    for (var key in obj) {
-                        // find dataset in array
-                        if (obj[key][2] == true) {
-                            for (var dset in powerchartData.datasets) {
-                                let leb = powerchartData.datasets[dset].label;
-                                if (leb == key) {
-                                    powerchartData.datasets[dset].data.push(obj[key][0]);
-                                }
-                            }
-                        }
-                        // update data view
-                        var element = document.getElementById(key);
-                        element.innerHTML = "<a href=\"/value/" + key + "\">" + key + "</a>: " +
-                                            obj[key][0] + "&#8239;" + obj[key][1];
-                        powerchart.update();
-                    }
-                }
+      } else {
+        for(var key in obj){
+          if(obj[key][2]==true){
+            for(var d in powerchartData.datasets){
+              if(powerchartData.datasets[d].label==key){
+                powerchartData.datasets[d].data.push(obj[key][0]);
+              }
             }
+          }
+          var el = document.getElementById(key);
+          if(el) el.innerHTML = '<a href="/value/'+key+'">'+key+'</a>: '+obj[key][0]+'\u202F'+obj[key][1];
+          powerchart.update();
         }
-        xhttp.open("GET", "./uiStatus", true);
-        xhttp.send();
-    }, 5000);
+      }
+    }
+  };
+  xhttp.open("GET","./uiStatus",true);
+  xhttp.send();
+}, 5000);
+
+/* ---- Config tab ---- */
+function loadConfig(){
+  fetch('./config').then(function(r){return r.json()}).then(function(d){
+    var fields = ['hostname','static_ip','static_netmask','static_gateway','static_dns',
+      'mqtt_server','mqtt_port','mqtt_topic','mqtt_user','cloud_serial','cloud_server',
+      'auth_user','syslog_ip'];
+    for(var i=0;i<fields.length;i++){
+      var el = document.getElementById('c_'+fields[i]);
+      if(el && d[fields[i]]!==undefined) el.value = d[fields[i]];
+    }
+    var mh = document.getElementById('c_mqtt_pwd_hint');
+    if(mh) mh.textContent = d.mqtt_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+    var ah = document.getElementById('c_auth_pwd_hint');
+    if(ah) ah.textContent = d.auth_pwd_set ? 'Password is set. Leave blank to keep.' : 'No password set.';
+  }).catch(function(e){
+    showCfgMsg('Failed to load config: '+e, true);
+  });
+}
+
+document.getElementById('cfgForm').addEventListener('submit', function(ev){
+  ev.preventDefault();
+  var msg = document.getElementById('cfgMsg');
+  msg.className = 'cfg-msg';
+  msg.textContent = 'Saving...';
+  msg.style.display = 'block';
+  fetch('./saveConfig', {
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+    body: new URLSearchParams(new FormData(this))
+  }).then(function(r){return r.json()}).then(function(d){
+    if(d.ok){
+      showCfgMsg(d.restart ? 'Saved! Restarting device...' : 'Configuration saved.', false);
+    } else {
+      showCfgMsg('Save failed.', true);
+    }
+  }).catch(function(e){
+    showCfgMsg('Error: '+e, true);
+  });
+});
+
+function showCfgMsg(text, isErr){
+  var el = document.getElementById('cfgMsg');
+  el.className = 'cfg-msg ' + (isErr ? 'err' : 'ok');
+  el.textContent = text;
+}
+
+/* ---- Cloud tab polling ---- */
+var cloudInterval = null;
+function fetchCloud(){
+  fetch('./cloudStatus').then(function(r){return r.json()}).then(function(d){
+    if(d.supported===false){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Not compiled</span>';
+      return;
+    }
+    if(!d.enabled){
+      document.getElementById('cl_state').innerHTML = '<span class="badge badge-off">Disabled</span>';
+      document.getElementById('cl_serial').textContent = 'Not configured';
+      return;
+    }
+    var sc = d.stateCode || 0;
+    var bc = sc >= 3 ? 'badge-ok' : (sc >= 1 ? 'badge-warn' : 'badge-err');
+    if(sc === 5) bc = 'badge-err';
+    document.getElementById('cl_state').innerHTML = '<span class="badge '+bc+'">'+d.state+'</span>';
+    document.getElementById('cl_serial').textContent = d.serial || '--';
+    document.getElementById('cl_server').textContent = d.server || '--';
+    document.getElementById('cl_sent').textContent = d.packetsSent;
+    document.getElementById('cl_recv').textContent = d.packetsRecv;
+    document.getElementById('cl_recon').textContent = d.reconnects;
+    document.getElementById('cl_last').textContent = d.lastSendAgo >= 0 ? d.lastSendAgo+'s ago' : 'never';
+  }).catch(function(){});
+}
+
+/* Start/stop cloud polling based on tab visibility */
+var origTabClick = null;
+document.querySelectorAll('.tabs button').forEach(function(btn){
+  btn.addEventListener('click', function(){
+    if(btn.getAttribute('data-tab')==='cloud'){
+      fetchCloud();
+      if(!cloudInterval) cloudInterval = setInterval(fetchCloud, 10000);
+    } else {
+      if(cloudInterval){clearInterval(cloudInterval); cloudInterval=null;}
+    }
+  });
+});
+
+/* ---- System tab ---- */
+function fetchSystem(){
+  fetch('./systemStatus').then(function(r){return r.json()}).then(function(d){
+    document.getElementById('s_host').textContent = d.hostname || '--';
+    document.getElementById('s_ip').textContent = d.ip || '--';
+    document.getElementById('s_gw').textContent = d.gateway || '--';
+    document.getElementById('s_mask').textContent = d.netmask || '--';
+    document.getElementById('s_dns').textContent = d.dns || '--';
+    document.getElementById('s_ssid').textContent = d.ssid || '--';
+    document.getElementById('s_mac').textContent = d.mac || '--';
+    document.getElementById('s_rssi').textContent = (d.rssi || 0) + ' dBm';
+    document.getElementById('s_heap').textContent = d.heap ? (d.heap + ' bytes') : '--';
+    var up = d.uptime || 0;
+    var h = Math.floor(up/3600); var m = Math.floor((up - h*3600)/60); var s = up - h*3600 - m*60;
+    document.getElementById('s_up').textContent = h+'h '+m+'m '+s+'s';
+    document.getElementById('s_stick').textContent = d.stickType || '--';
+  }).catch(function(){});
+}
 </script>
+</main>
 </body>
 </html>
-)=====";
+)rawliteral";
 
 const char SendPostSite_page[] PROGMEM = R"=====(
 <!DOCTYPE HTML><html>

--- a/SRC/ShineWiFi-ModBus/Index.h
+++ b/SRC/ShineWiFi-ModBus/Index.h
@@ -8,7 +8,7 @@ const char MAIN_page[] PROGMEM = R"rawliteral(
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Growatt Inverter</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css"
-  onerror="document.body.classList.add('no-cdn')">
+  onerror="document.documentElement.classList.add('no-cdn')">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.2.1/chart.umd.min.js"
   integrity="sha512-GCiwmzA0bNGVsp1otzTJ4LWQT2jjGJENLGyLlerlzckNI30moi2EQT0AfRI7fLYYYDKR+7hnuh35r3y1uJzugw=="
   crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -312,7 +312,6 @@ function fetchCloud(){
 }
 
 /* Start/stop cloud polling based on tab visibility */
-var origTabClick = null;
 document.querySelectorAll('.tabs button').forEach(function(btn){
   btn.addEventListener('click', function(){
     if(btn.getAttribute('data-tab')==='cloud'){

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -11,6 +11,12 @@
 #include <WiFiManager.h>
 #include <StreamUtils.h>
 
+#ifdef ESP8266
+#include <Updater.h>
+#elif defined(ESP32)
+#include <Update.h>
+#endif
+
 #ifdef ESP32
 #include <esp_task_wdt.h>
 #endif
@@ -37,6 +43,10 @@ DoubleResetDetector* drd;
 #include "ShineMqtt.h"
 #endif
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+#include "GrowattCloud.h"
+#endif
+
 #if OTA_SUPPORTED == 1
 #include <ArduinoOTA.h>
 #endif
@@ -57,6 +67,11 @@ WiFiClientSecure espClient;
 WiFiClient espClient;
 #endif
 ShineMqtt shineMqtt(espClient, Inverter);
+#endif
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+GrowattCloud growattCloud;
+WiFiClient growattCloudClient;
 #endif
 
 #ifdef AP_BUTTON_PRESSED
@@ -92,7 +107,15 @@ struct {
   WiFiManagerParameter* mqtt_user = NULL;
   WiFiManagerParameter* mqtt_pwd = NULL;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  WiFiManagerParameter* cloud_serial = NULL;
+  WiFiManagerParameter* cloud_server = NULL;
+#endif
   WiFiManagerParameter* syslog_ip = NULL;
+#if ENABLE_WEB_AUTH == 1
+  WiFiManagerParameter* auth_user = NULL;
+  WiFiManagerParameter* auth_pass = NULL;
+#endif
 } customWMParams;
 
 static const struct {
@@ -108,7 +131,15 @@ static const struct {
   const char* mqtt_user = "/mqttu";
   const char* mqtt_pwd = "/mqttw";
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  const char* cloud_serial = "/cloudsn";
+  const char* cloud_server = "/cloudsrv";
+#endif
   const char* syslog_ip = "/syslogip";
+#if ENABLE_WEB_AUTH == 1
+  const char* auth_user = "/authuser";
+  const char* auth_pass = "/authpass";
+#endif
   const char* force_ap = "/forceap";
 } ConfigFiles;
 
@@ -121,7 +152,15 @@ struct {
 #if MQTT_SUPPORTED == 1
   MqttConfig mqtt;
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  String cloud_serial;
+  String cloud_server;
+#endif
   String syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  String auth_user;
+  String auth_pass;
+#endif
   bool force_ap;
 } Config;
 
@@ -210,7 +249,15 @@ void loadConfig() {
   Config.mqtt.user = prefs.getString(ConfigFiles.mqtt_user, "");
   Config.mqtt.pwd = prefs.getString(ConfigFiles.mqtt_pwd, "");
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = prefs.getString(ConfigFiles.cloud_serial, "");
+  Config.cloud_server = prefs.getString(ConfigFiles.cloud_server, "server.growatt.com");
+#endif
   Config.syslog_ip = prefs.getString(ConfigFiles.syslog_ip, "");
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = prefs.getString(ConfigFiles.auth_user, "");
+  Config.auth_pass = prefs.getString(ConfigFiles.auth_pass, "");
+#endif
   Config.force_ap = prefs.getBool(ConfigFiles.force_ap, false);
 }
 
@@ -227,7 +274,15 @@ void saveConfig() {
   prefs.putString(ConfigFiles.mqtt_user, Config.mqtt.user);
   prefs.putString(ConfigFiles.mqtt_pwd, Config.mqtt.pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  prefs.putString(ConfigFiles.cloud_serial, Config.cloud_serial);
+  prefs.putString(ConfigFiles.cloud_server, Config.cloud_server);
+#endif
   prefs.putString(ConfigFiles.syslog_ip, Config.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  prefs.putString(ConfigFiles.auth_user, Config.auth_user);
+  prefs.putString(ConfigFiles.auth_pass, Config.auth_pass);
+#endif
 }
 
 void saveParamCallback() {
@@ -248,7 +303,21 @@ void saveParamCallback() {
   Config.mqtt.user = customWMParams.mqtt_user->getValue();
   Config.mqtt.pwd = customWMParams.mqtt_pwd->getValue();
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  Config.cloud_serial = customWMParams.cloud_serial->getValue();
+  Config.cloud_server = customWMParams.cloud_server->getValue();
+  if (Config.cloud_server.isEmpty()) {
+    Config.cloud_server = "server.growatt.com";
+  }
+#endif
   Config.syslog_ip = customWMParams.syslog_ip->getValue();
+#if ENABLE_WEB_AUTH == 1
+  Config.auth_user = customWMParams.auth_user->getValue();
+  {
+    String val = customWMParams.auth_pass->getValue();
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
 
   saveConfig();
 
@@ -471,11 +540,63 @@ void setup() {
 #ifdef ENABLE_WEB_DEBUG
   httpServer.on("/debug", sendDebug);
 #endif
+  httpServer.on("/config", HTTP_GET, sendConfigJson);
+  httpServer.on("/saveConfig", HTTP_POST, handleSaveConfig);
+  httpServer.on("/cloudStatus", sendCloudStatus);
+  httpServer.on("/systemStatus", sendSystemStatus);
+  httpServer.on("/update", HTTP_GET, sendUpdatePage);
+  httpServer.on("/doUpdate", HTTP_POST, handleUpdateDone, handleUpdateUpload);
   httpServer.onNotFound(handleNotFound);
 
   Inverter.InitProtocol();
   InverterReconnect();
   httpServer.begin();
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Try to auto-read serial from stock firmware's flash area (0x3FD0B4)
+  // This survives OIG flashing since we only write the first ~500KB
+  if (Config.cloud_serial.isEmpty()) {
+    uint8_t flashBuf[12] = {0};
+    char flashSerial[11] = {0};
+    bool found = false;
+#ifdef ESP8266
+    if (ESP.flashRead(0x3FD0B4, (uint32_t*)flashBuf, 12)) {
+      memcpy(flashSerial, flashBuf, 10);
+      flashSerial[10] = '\0';
+      found = true;
+      for (int i = 0; i < 10 && found; i++) {
+        if (flashSerial[i] < 0x20 || flashSerial[i] > 0x7E) {
+          if (i == 0) found = false;
+          else flashSerial[i] = '\0';
+        }
+      }
+    }
+#endif
+    if (found && strlen(flashSerial) >= 6) {
+      Config.cloud_serial = String(flashSerial);
+      saveConfig();
+      Log.print(F("[GrowattCloud] Auto-detected serial from flash: "));
+      Log.println(Config.cloud_serial);
+    }
+  }
+
+  if (!Config.cloud_serial.isEmpty()) {
+    GrowattCloudConfig cloudCfg;
+    strncpy(cloudCfg.serverHost, Config.cloud_server.c_str(), sizeof(cloudCfg.serverHost) - 1);
+    cloudCfg.serverPort = GROWATT_PORT_DEFAULT;
+    cloudCfg.protocolId = GROWATT_PROTO_ENC_V2;
+    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), GROWATT_SERIAL_LEN);
+    memset(cloudCfg.inverterSerial, 0, sizeof(cloudCfg.inverterSerial));
+    strncpy(cloudCfg.fwVersion, "1.7.7.7", sizeof(cloudCfg.fwVersion) - 1);
+    cloudCfg.logIntervalMin = 5;
+    cloudCfg.enabled = true;
+    growattCloud.begin(cloudCfg);
+    Log.println(F("[GrowattCloud] Enabled, serial: "));
+    Log.println(Config.cloud_serial);
+  } else {
+    Log.println(F("[GrowattCloud] Disabled (no serial configured)"));
+  }
+#endif
 
 #if defined(DEFAULT_NTP_SERVER) && defined(DEFAULT_TZ_INFO)
 #ifdef ESP32
@@ -524,6 +645,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.mqtt_user);
   wm.addParameter(customWMParams.mqtt_pwd);
 #endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  customWMParams.cloud_serial = new WiFiManagerParameter(
+      "cloudsn", "Datalogger Serial (from stick label/AP SSID)",
+      Config.cloud_serial.c_str(), 30);
+  customWMParams.cloud_server = new WiFiManagerParameter(
+      "cloudsrv", "Cloud Server (default: server.growatt.com)",
+      Config.cloud_server.c_str(), 60);
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Growatt Cloud</b> (enter serial to enable, leave blank to disable)</p>"));
+  wm.addParameter(customWMParams.cloud_serial);
+  wm.addParameter(customWMParams.cloud_server);
+#endif
   wm.addParameter(new WiFiManagerParameter(
       "<p><b>Static IP</b> (leave blank for DHCP)</p>"));
   wm.addParameter(customWMParams.static_ip);
@@ -532,6 +665,18 @@ void setupWifiManagerConfigMenu(WiFiManager& wm) {
   wm.addParameter(customWMParams.static_dns);
   wm.addParameter(new WiFiManagerParameter("<p><b>Advanced Settings</b></p>"));
   wm.addParameter(customWMParams.syslog_ip);
+#if ENABLE_WEB_AUTH == 1
+  customWMParams.auth_user = new WiFiManagerParameter(
+      "authuser", "Web UI Username (blank=no auth)",
+      Config.auth_user.c_str(), 30);
+  customWMParams.auth_pass = new WiFiManagerParameter(
+      "authpass", "Web UI Password",
+      "", 30);  // Don't show current password
+  wm.addParameter(new WiFiManagerParameter(
+      "<p><b>Web Authentication</b> (leave blank for open access)</p>"));
+  wm.addParameter(customWMParams.auth_user);
+  wm.addParameter(customWMParams.auth_pass);
+#endif
 
   wm.setSaveParamsCallback(saveParamCallback);
 
@@ -556,6 +701,19 @@ void setupMenu(WiFiManager& wm, bool enableCustomParams) {
   wm.setMenu(menu);  // custom menu, pass vector
 }
 
+bool checkAuth() {
+#if ENABLE_WEB_AUTH == 1
+  if (Config.auth_user.isEmpty() || Config.auth_pass.isEmpty()) {
+    return true;
+  }
+  if (!httpServer.authenticate(Config.auth_user.c_str(), Config.auth_pass.c_str())) {
+    httpServer.requestAuthentication(BASIC_AUTH, "Growatt Inverter");
+    return false;
+  }
+#endif
+  return true;
+}
+
 void sendJson(JsonDocument& doc) {
   httpServer.setContentLength(measureJson(doc));
   httpServer.send(200, "application/json", "");
@@ -565,6 +723,7 @@ void sendJson(JsonDocument& doc) {
 }
 
 void sendJsonSite(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -577,6 +736,7 @@ void sendJsonSite(void) {
 }
 
 void sendUiJsonSite(void) {
+  if (!checkAuth()) return;
   DynamicJsonDocument doc(JSON_DOCUMENT_SIZE);
   Inverter.CreateUIJson(doc, Config.hostname);
 
@@ -584,6 +744,7 @@ void sendUiJsonSite(void) {
 }
 
 void sendMetrics(void) {
+  if (!checkAuth()) return;
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
     return;
@@ -616,6 +777,7 @@ boolean sendMqttJson(void) {
 #endif
 
 void startConfigAccessPoint(void) {
+  if (!checkAuth()) return;
   char msg[384];
 
   snprintf_P(msg, sizeof(msg),
@@ -632,6 +794,7 @@ void startConfigAccessPoint(void) {
 }
 
 void rebootESP(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, F("text/html"),
                   F("<html><body>Rebooting...</body></html>"));
   delay(2000);
@@ -640,19 +803,25 @@ void rebootESP(void) {
 
 #ifdef ENABLE_WEB_DEBUG
 void sendDebug(void) {
+  if (!checkAuth()) return;
   httpServer.sendHeader("Location",
                         "http://" + WiFi.localIP().toString() + ":8080/", true);
   httpServer.send(302, "text/plain", "");
 }
 #endif
 
-void sendMainPage(void) { httpServer.send(200, "text/html", MAIN_page); }
+void sendMainPage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, "text/html", MAIN_page);
+}
 
 void sendPostSite(void) {
+  if (!checkAuth()) return;
   httpServer.send(200, "text/html", SendPostSite_page);
 }
 
 void handlePostData() {
+  if (!checkAuth()) return;
   char msg[256];
   uint16_t u16Tmp;
   uint32_t u32Tmp;
@@ -747,6 +916,176 @@ void handlePostData() {
   }
 }
 
+// -------------------------------------------------------
+// OTA Firmware Update via Web UI
+// -------------------------------------------------------
+void sendUpdatePage(void) {
+  if (!checkAuth()) return;
+  httpServer.send(200, F("text/html"),
+    F("<!DOCTYPE html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>"
+      "<title>Firmware Update</title>"
+      "<link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css'>"
+      "</head><body><main class='container'>"
+      "<h2>Firmware Update</h2>"
+      "<form method='POST' action='/doUpdate' enctype='multipart/form-data'>"
+      "<label>Select firmware .bin file:<input type='file' name='update' accept='.bin' required></label>"
+      "<button type='submit'>Upload and Flash</button>"
+      "</form>"
+      "<p><a href='/'>Back to Dashboard</a></p>"
+      "</main></body></html>"));
+}
+
+void handleUpdateUpload(void) {
+  if (!checkAuth()) return;
+  HTTPUpload& upload = httpServer.upload();
+  if (upload.status == UPLOAD_FILE_START) {
+    Log.printf("OTA Update: %s (%u bytes)\n", upload.filename.c_str(), upload.totalSize);
+    uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
+    if (!Update.begin(maxSketchSpace)) {
+      Log.println(F("OTA: Not enough space"));
+    }
+  } else if (upload.status == UPLOAD_FILE_WRITE) {
+    if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
+      Log.println(F("OTA: Write failed"));
+    }
+  } else if (upload.status == UPLOAD_FILE_END) {
+    if (Update.end(true)) {
+      Log.printf("OTA: Success, %u bytes\n", upload.totalSize);
+    } else {
+      Log.println(F("OTA: Failed"));
+    }
+  }
+  yield();
+}
+
+void handleUpdateDone(void) {
+  if (!checkAuth()) return;
+  bool ok = !Update.hasError();
+  httpServer.send(200, F("text/html"),
+    ok ? F("<!DOCTYPE html><html><body><h2>Update Successful!</h2><p>Rebooting...</p></body></html>")
+       : F("<!DOCTYPE html><html><body><h2>Update Failed!</h2><p><a href='/update'>Try again</a></p></body></html>"));
+  if (ok) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendConfigJson(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<512> doc;
+  doc["hostname"] = Config.hostname;
+  doc["static_ip"] = Config.static_ip;
+  doc["static_netmask"] = Config.static_netmask;
+  doc["static_gateway"] = Config.static_gateway;
+  doc["static_dns"] = Config.static_dns;
+#if MQTT_SUPPORTED == 1
+  doc["mqtt_server"] = Config.mqtt.server;
+  doc["mqtt_port"] = Config.mqtt.port;
+  doc["mqtt_topic"] = Config.mqtt.topic;
+  doc["mqtt_user"] = Config.mqtt.user;
+  doc["mqtt_pwd_set"] = !Config.mqtt.pwd.isEmpty();
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloud_serial"] = Config.cloud_serial;
+  doc["cloud_server"] = Config.cloud_server;
+#endif
+  doc["syslog_ip"] = Config.syslog_ip;
+#if ENABLE_WEB_AUTH == 1
+  doc["auth_user"] = Config.auth_user;
+  doc["auth_pwd_set"] = !Config.auth_pass.isEmpty();
+#endif
+  sendJson(doc);
+}
+
+void handleSaveConfig(void) {
+  if (!checkAuth()) return;
+  if (httpServer.hasArg(F("hostname"))) Config.hostname = httpServer.arg(F("hostname"));
+  if (httpServer.hasArg(F("static_ip"))) Config.static_ip = httpServer.arg(F("static_ip"));
+  if (httpServer.hasArg(F("static_netmask"))) Config.static_netmask = httpServer.arg(F("static_netmask"));
+  if (httpServer.hasArg(F("static_gateway"))) Config.static_gateway = httpServer.arg(F("static_gateway"));
+  if (httpServer.hasArg(F("static_dns"))) Config.static_dns = httpServer.arg(F("static_dns"));
+#if MQTT_SUPPORTED == 1
+  if (httpServer.hasArg(F("mqtt_server"))) Config.mqtt.server = httpServer.arg(F("mqtt_server"));
+  if (httpServer.hasArg(F("mqtt_port"))) Config.mqtt.port = httpServer.arg(F("mqtt_port"));
+  if (httpServer.hasArg(F("mqtt_topic"))) Config.mqtt.topic = httpServer.arg(F("mqtt_topic"));
+  if (httpServer.hasArg(F("mqtt_user"))) Config.mqtt.user = httpServer.arg(F("mqtt_user"));
+  if (httpServer.hasArg(F("mqtt_pwd"))) {
+    String val = httpServer.arg(F("mqtt_pwd"));
+    if (!val.isEmpty()) Config.mqtt.pwd = val;
+  }
+#endif
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (httpServer.hasArg(F("cloud_serial"))) Config.cloud_serial = httpServer.arg(F("cloud_serial"));
+  if (httpServer.hasArg(F("cloud_server"))) {
+    String val = httpServer.arg(F("cloud_server"));
+    Config.cloud_server = val.isEmpty() ? "server.growatt.com" : val;
+  }
+#endif
+  if (httpServer.hasArg(F("syslog_ip"))) Config.syslog_ip = httpServer.arg(F("syslog_ip"));
+#if ENABLE_WEB_AUTH == 1
+  if (httpServer.hasArg(F("auth_user"))) Config.auth_user = httpServer.arg(F("auth_user"));
+  if (httpServer.hasArg(F("auth_pass"))) {
+    String val = httpServer.arg(F("auth_pass"));
+    if (!val.isEmpty()) Config.auth_pass = val;
+  }
+#endif
+  saveConfig();
+  bool needRestart = httpServer.hasArg(F("restart"));
+  httpServer.send(200, F("application/json"),
+    needRestart ? F("{\"ok\":true,\"restart\":true}") : F("{\"ok\":true}"));
+  if (needRestart) {
+    delay(1000);
+    ESP.restart();
+  }
+}
+
+void sendCloudStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<256> doc;
+#if GROWATT_CLOUD_SUPPORTED == 1
+  if (!Config.cloud_serial.isEmpty()) {
+    doc["enabled"] = true;
+    const char* stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
+    doc["state"] = stateNames[growattCloud.getState()];
+    doc["stateCode"] = (int)growattCloud.getState();
+    doc["packetsSent"] = growattCloud.getPacketsSent();
+    doc["packetsRecv"] = growattCloud.getPacketsRecv();
+    doc["reconnects"] = growattCloud.getReconnects();
+    uint32_t lastSend = growattCloud.getLastSendTime();
+    doc["lastSendAgo"] = lastSend > 0 ? (int)((millis() - lastSend) / 1000) : -1;
+    doc["serial"] = Config.cloud_serial;
+    doc["server"] = Config.cloud_server;
+  } else {
+    doc["enabled"] = false;
+  }
+#else
+  doc["supported"] = false;
+#endif
+  sendJson(doc);
+}
+
+void sendSystemStatus(void) {
+  if (!checkAuth()) return;
+  StaticJsonDocument<384> doc;
+  doc["hostname"] = Config.hostname;
+  doc["ip"] = WiFi.localIP().toString();
+  doc["gateway"] = WiFi.gatewayIP().toString();
+  doc["netmask"] = WiFi.subnetMask().toString();
+  doc["dns"] = WiFi.dnsIP().toString();
+  doc["ssid"] = WiFi.SSID();
+  doc["rssi"] = WiFi.RSSI();
+  doc["heap"] = ESP.getFreeHeap();
+  doc["uptime"] = millis() / 1000;
+  doc["mac"] = WiFi.macAddress();
+  doc["stickType"] = Inverter.GetWiFiStickType() == ShineWiFi_S ? "ShineWiFi-S" :
+                     Inverter.GetWiFiStickType() == ShineWiFi_X ? "ShineWiFi-X" : "Unknown";
+#if GROWATT_CLOUD_SUPPORTED == 1
+  doc["cloudSerial"] = Config.cloud_serial;
+  doc["cloudState"] = growattCloud.isConnected() ? "Active" : "Disconnected";
+#endif
+  sendJson(doc);
+}
+
 bool sendSingleValue(void) {
   if (!readoutSucceeded) {
     httpServer.send(503, F("text/plain"), F("Service Unavailable"));
@@ -762,6 +1101,7 @@ bool sendSingleValue(void) {
 }
 
 void handleNotFound() {
+  if (!checkAuth()) return;
   if (httpServer.uri().startsWith(F("/value/")) &&
       httpServer.uri().length() > 7) {
     if (sendSingleValue()) {
@@ -896,6 +1236,24 @@ void loop() {
 #endif
           handleWdtReset(mqttSuccess);
 
+#if GROWATT_CLOUD_SUPPORTED == 1
+          // Feed register data to Growatt Cloud sender
+          if (!Config.cloud_serial.isEmpty()) {
+            // Build arrays of raw register values for cloud protocol
+            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
+            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            uint16_t inputRegs[125];
+            uint16_t holdingRegs[35];
+            for (uint16_t i = 0; i < numInput && i < 125; i++) {
+              inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
+            }
+            for (uint16_t i = 0; i < numHolding && i < 35; i++) {
+              holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
+            }
+            growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);
+          }
+#endif
+
           // leave while-loop
           readoutSucceeded = true;
         } else {
@@ -943,6 +1301,13 @@ void loop() {
 
     RefreshTimer = now;
   }
+
+#if GROWATT_CLOUD_SUPPORTED == 1
+  // Keep Growatt Cloud connection alive (pings, server responses)
+  if (!Config.cloud_serial.isEmpty()) {
+    growattCloud.loop(nullptr, 0);
+  }
+#endif
 
 #if OTA_SUPPORTED == 1
   // check for OTA updates

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -550,6 +550,9 @@ void setup() {
 
   Inverter.InitProtocol();
   InverterReconnect();
+  // Collect Origin and Referer so checkSameOrigin() can inspect them.
+  const char* csrfHeaders[] = {"Origin", "Referer"};
+  httpServer.collectHeaders(csrfHeaders, sizeof(csrfHeaders) / sizeof(csrfHeaders[0]));
   httpServer.begin();
 
 #if GROWATT_CLOUD_SUPPORTED == 1
@@ -581,13 +584,16 @@ void setup() {
   }
 
   if (!Config.cloud_serial.isEmpty()) {
-    GrowattCloudConfig cloudCfg;
+    GrowattCloudConfig cloudCfg = {};
     strncpy(cloudCfg.serverHost, Config.cloud_server.c_str(), sizeof(cloudCfg.serverHost) - 1);
+    cloudCfg.serverHost[sizeof(cloudCfg.serverHost) - 1] = '\0';
     cloudCfg.serverPort = GROWATT_PORT_DEFAULT;
     cloudCfg.protocolId = GROWATT_PROTO_ENC_V2;
-    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), GROWATT_SERIAL_LEN);
-    memset(cloudCfg.inverterSerial, 0, sizeof(cloudCfg.inverterSerial));
+    strncpy(cloudCfg.dataloggerSerial, Config.cloud_serial.c_str(), sizeof(cloudCfg.dataloggerSerial) - 1);
+    cloudCfg.dataloggerSerial[sizeof(cloudCfg.dataloggerSerial) - 1] = '\0';
+    // inverterSerial already zeroed by the {} initializer above
     strncpy(cloudCfg.fwVersion, "1.7.7.7", sizeof(cloudCfg.fwVersion) - 1);
+    cloudCfg.fwVersion[sizeof(cloudCfg.fwVersion) - 1] = '\0';
     cloudCfg.logIntervalMin = 5;
     cloudCfg.enabled = true;
     growattCloud.begin(cloudCfg);
@@ -712,6 +718,31 @@ bool checkAuth() {
   }
 #endif
   return true;
+}
+
+// CSRF mitigation for state-changing endpoints. Browsers send Basic Auth
+// credentials automatically, so a cross-site POST could otherwise reconfigure
+// the device. Require that the Origin (or Referer) header points at this
+// device. Same-origin form posts from the device's own pages always include
+// one of these; cross-site posts will not (or will point elsewhere).
+bool checkSameOrigin() {
+  String host = httpServer.hostHeader();
+  String origin = httpServer.header(F("Origin"));
+  String referer = httpServer.header(F("Referer"));
+  auto matches = [&host](const String& url) -> bool {
+    if (url.isEmpty() || host.isEmpty()) return false;
+    int schemeEnd = url.indexOf(F("://"));
+    if (schemeEnd < 0) return false;
+    int hostStart = schemeEnd + 3;
+    int hostEnd = url.indexOf('/', hostStart);
+    String urlHost = (hostEnd < 0) ? url.substring(hostStart)
+                                   : url.substring(hostStart, hostEnd);
+    return urlHost.equalsIgnoreCase(host);
+  };
+  if (!origin.isEmpty()) return matches(origin);
+  if (!referer.isEmpty()) return matches(referer);
+  // Neither header present: reject state-changing request to be safe.
+  return false;
 }
 
 void sendJson(JsonDocument& doc) {
@@ -999,6 +1030,10 @@ void sendConfigJson(void) {
 
 void handleSaveConfig(void) {
   if (!checkAuth()) return;
+  if (!checkSameOrigin()) {
+    httpServer.send(403, F("text/plain"), F("Forbidden: cross-origin request rejected"));
+    return;
+  }
   if (httpServer.hasArg(F("hostname"))) Config.hostname = httpServer.arg(F("hostname"));
   if (httpServer.hasArg(F("static_ip"))) Config.static_ip = httpServer.arg(F("static_ip"));
   if (httpServer.hasArg(F("static_netmask"))) Config.static_netmask = httpServer.arg(F("static_netmask"));
@@ -1045,9 +1080,11 @@ void sendCloudStatus(void) {
 #if GROWATT_CLOUD_SUPPORTED == 1
   if (!Config.cloud_serial.isEmpty()) {
     doc["enabled"] = true;
-    const char* stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
-    doc["state"] = stateNames[growattCloud.getState()];
-    doc["stateCode"] = (int)growattCloud.getState();
+    static const char* const stateNames[] = {"Disconnected","Connecting","Connected","Announced","Active","Error"};
+    int sIdx = (int)growattCloud.getState();
+    doc["state"] = (sIdx >= 0 && sIdx < (int)(sizeof(stateNames)/sizeof(stateNames[0])))
+                      ? stateNames[sIdx] : "Unknown";
+    doc["stateCode"] = sIdx;
     doc["packetsSent"] = growattCloud.getPacketsSent();
     doc["packetsRecv"] = growattCloud.getPacketsRecv();
     doc["reconnects"] = growattCloud.getReconnects();
@@ -1239,15 +1276,19 @@ void loop() {
 #if GROWATT_CLOUD_SUPPORTED == 1
           // Feed register data to Growatt Cloud sender
           if (!Config.cloud_serial.isEmpty()) {
-            // Build arrays of raw register values for cloud protocol
-            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
-            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            // Build arrays of raw register values for cloud protocol.
+            // Cap counts to the local buffer sizes so the downstream callee
+            // never reads past inputRegs[]/holdingRegs[].
             uint16_t inputRegs[125];
             uint16_t holdingRegs[35];
-            for (uint16_t i = 0; i < numInput && i < 125; i++) {
+            uint16_t numInput = Inverter._Protocol.InputRegisterCount;
+            uint16_t numHolding = Inverter._Protocol.HoldingRegisterCount;
+            if (numInput > 125) numInput = 125;
+            if (numHolding > 35) numHolding = 35;
+            for (uint16_t i = 0; i < numInput; i++) {
               inputRegs[i] = (uint16_t)Inverter._Protocol.InputRegisters[i].value;
             }
-            for (uint16_t i = 0; i < numHolding && i < 35; i++) {
+            for (uint16_t i = 0; i < numHolding; i++) {
               holdingRegs[i] = (uint16_t)Inverter._Protocol.HoldingRegisters[i].value;
             }
             growattCloud.loop(inputRegs, numInput, holdingRegs, numHolding);


### PR DESCRIPTION
## Summary

- Expands the v3.05 protocol's input register map from 12 mapped values to 34, covering Modbus input registers 0-43. Adds per-PV-string fields, per-phase grid fields for 3-phase inverters, fault state, IPM temperature, and bus voltages.
- Adds `Growatt::ReadInputRegFrag()` as a sibling to the existing `ReadHoldingRegFrag()` for raw FC04 block reads that bypass the protocol map.

## Motivation

The v3.05 map only covered single-phase basics, so 3-phase ShineWiFi-S setups (e.g. Growatt 4000TL3-S) lost the per-phase voltages/currents/powers, fault codes, and thermal data even though the inverter reports them via FC04. Local UI, MQTT, and Prometheus all now see this data.

The new `ReadInputRegFrag()` helper exists because some Growatt inverters return FC04 data with a register-address shift in higher ranges (e.g. doc reg 47-89 returned when requesting start=45). The standard fragment math binds the Modbus request address and the buffer index together, so callers that need to handle a shift have to do the raw read themselves and place values at the correct destination indices. This PR doesn't take advantage of that yet — it's groundwork for a follow-up that fixes the cloud DATA packet's block 2 (registers 47-89), which is currently sent as all zeros.

## Changes

- `Growatt305.cpp/.h`: 22 new InputRegister entries (sorted by address), `InputRegisterCount` 12 -> 34, fragment grows from `{0, 33}` to `{0, 45}`.
- `Growatt.cpp/.h`: adds `ReadInputRegFrag(adr, size, uint16_t* result)`.

## Test plan

- [x] Builds clean for `ShineWifiS` env on this branch
- [x] Verified live on Growatt 4000TL3-S (DTC=42) via ShineWiFi-S: `/status` now returns all 34 fields with realistic values (DcPower, Pv1Power, Pv2*, PacTotal, AcPower/AcPower L2/L3, EnergyToday/Total, Temperature, IpmTemperature, P/NBusVoltage, faults)
- [x] No change to existing 12 enum positions — external references by name still work

## Notes / follow-ups

- This PR stacks on #528. Without #528's web-ui scaffolding merged, the cloud-feed code that consumes these registers doesn't exist yet — but the protocol map and helper are independently useful for MQTT/UI users.
- Block 2 input registers (47-89) for the cloud DATA packet still need a follow-up because of the FC04 +2 shift quirk on the TL3-S. The new `ReadInputRegFrag()` helper is the building block for that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)