### PR TITLE
fix: make val optional for read operations on RW Modbus endpoint

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -657,11 +657,12 @@ void handlePostData() {
   uint16_t u16Tmp;
   uint32_t u32Tmp;
 
-  if (!httpServer.hasArg(F("reg")) || !httpServer.hasArg(F("val"))) {
-    // If the POST request doesn't have data
-    httpServer.send(400, F("text/plain"),
-                    F("400: Invalid Request"));  // The request is invalid, so
-                                                 // send HTTP status 400
+  // `reg` is always required. `val` is only required for write operations;
+  // reads ignore it. This lets clients omit val (or pass a dummy 0) for reads.
+  const bool isWrite = httpServer.arg(F("operation")) == "W";
+  if (!httpServer.hasArg(F("reg")) ||
+      (isWrite && !httpServer.hasArg(F("val")))) {
+    httpServer.send(400, F("text/plain"), F("400: Invalid Request"));
     return;
   } else {
     if (httpServer.arg(F("operation")) == "R") {


### PR DESCRIPTION
## Summary

`handlePostData()` rejects any request that's missing either `reg` or `val`, even though `val` is only used for write operations. Clients trying to **read** a register currently have to send a dummy `val=0` or get a 400.

This makes `val` required only when `operation=W`. Reads work as expected:

```
POST /postCommunicationModbus_p
reg=0&type=16b&operation=R&registerType=I
-> 200 OK
Read 16b input register 0 with value 1
```

(Previously this returned `400: Invalid Request`.)

## Test plan

- [x] Builds clean for ShineWifiS
- [x] Manual: `reg=0&type=16b&operation=R&registerType=I` (no `val`) now succeeds on a live ShineWiFi-S stick (HP returns `Read 16b input register 0 with value 1`)
- [x] Manual: writes still validate `val` (omitting it on `operation=W` still returns 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)